### PR TITLE
Meta: Rename package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - BREAKING: Drop compatibility support for prettier 2
 - BREAKING: Plugin system has been removed from this project
+- BREAKING: Package has been renamed `@zackad/prettier-plugin-twig-melody` -> `@zackad/prettier-plugin-twig`
 
 ### Internals
 - Remove npm script to publish

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Prettier for Melody
+# Prettier Plugin for Twig
+
+Forked from [trivago/prettier-plugin-twig-melody](https://github.com/trivago/prettier-plugin-twig-melody) with focus on twig template only.
 
 ![Prettier Banner](https://raw.githubusercontent.com/prettier/prettier-logo/master/images/prettier-banner-light.png)
 
@@ -9,18 +11,18 @@
 
 ---
 
-This Plugin enables Prettier to format `.twig` files, as well as `.html.twig` and `.melody.twig`. [Melody](https://melody.js.org) is a component based UI framework that uses Twig as its template language.
+This Plugin enables Prettier to format `.twig` files, as well as `.html.twig`.
 
 ## Install
 
 ```bash
-yarn add --dev @zackad/prettier-plugin-twig-melody
+yarn add --dev @zackad/prettier-plugin-twig
 ```
 
 ## Use
 
 ```bash
-prettier --write "**/*.melody.twig"
+prettier --write "**/*.twig"
 ```
 
 In your editor, if the plugin is not automatically picked up and invoked (e.g., if you are using format on save, but no formatting is happening when you save), try adding the plugin explicitly in your Prettier configuration (e.g., `.prettierrc.json`) using the `plugins` key:
@@ -29,7 +31,7 @@ In your editor, if the plugin is not automatically picked up and invoked (e.g., 
 {
     "printWidth": 80,
     "tabWidth": 4,
-    "plugins": ["@zackad/prettier-plugin-twig-melody"]
+    "plugins": ["@zackad/prettier-plugin-twig"]
 }
 ```
 
@@ -130,3 +132,7 @@ You can also tell Prettier to leave entire regions as they are:
 ## Testing
 
 -   You can call `yarn test`to test against all regular tests
+
+## Credit
+
+- Author: Tom Bartel <thomas.bartel@trivago.com>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "@zackad/prettier-plugin-twig-melody",
+    "name": "@zackad/prettier-plugin-twig",
     "version": "0.6.0",
-    "description": "Prettier Plugin for Twig/Melody",
-    "repository": "https://github.com/zackad/prettier-plugin-twig-melody",
+    "description": "Prettier Plugin for Twig",
+    "repository": "https://github.com/zackad/prettier-plugin-twig",
     "license": "Apache-2.0",
     "author": "Tom Bartel <thomas.bartel@trivago.com>",
     "type": "module",


### PR DESCRIPTION
The npm package has been renamed from `@zackad/prettier-plugin-twig-melody` into `@zackad/prettier-plugin-twig` to clearly indicate that this project is focusing only on formating twig template.