### PR TITLE
Integrate Melody Dependencies into core

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
         "test": "vitest --run"
     },
     "dependencies": {
+        "babel-template": "^6.26.0",
         "babel-types": "^6.26.0",
-        "melody-extension-core": "^1.7.5",
-        "melody-parser": "^1.7.5",
-        "melody-traverse": "^1.7.5",
-        "melody-types": "^1.7.5",
+        "he": "^1.2.0",
+        "lodash": "^4.17.21",
         "prettier": "^3.0.0",
         "resolve": "^1.12.0"
     },

--- a/src/melody/melody-code-frame/index.js
+++ b/src/melody/melody-code-frame/index.js
@@ -13,32 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import lineNumbers from './lineNumbers';
-import { repeat } from 'lodash';
+import lineNumbers from "./lineNumbers.js";
+import repeat from "lodash/repeat.js";
 
 const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
 
-export default function({ rawLines, lineNumber, colNumber, length }) {
-    const lines = rawLines.split(NEWLINE),
-        start = Math.max(lineNumber - 3, 0),
-        end = Math.min(lineNumber + 3, lines.length);
+export default function ({ rawLines, lineNumber, colNumber, length }) {
+    const lines = rawLines.split(NEWLINE);
+    const start = Math.max(lineNumber - 3, 0);
+    const end = Math.min(lineNumber + 3, lines.length);
 
     return lineNumbers(lines.slice(start, end), {
         start: start + 1,
-        before: '  ',
-        after: ' | ',
+        before: "  ",
+        after: " | ",
         transform(params) {
             if (params.number !== lineNumber) {
                 return;
             }
 
-            if (typeof colNumber === 'number') {
-                params.line += `\n${params.before}${repeat(' ', params.width)}${
+            if (typeof colNumber === "number") {
+                params.line += `\n${params.before}${repeat(" ", params.width)}${
                     params.after
-                }${repeat(' ', colNumber)}${repeat('^', length)}`;
+                }${repeat(" ", colNumber)}${repeat("^", length)}`;
             }
 
-            params.before = params.before.replace(/^./, '>');
-        },
-    }).join('\n');
+            params.before = params.before.replace(/^./, ">");
+        }
+    }).join("\n");
 }

--- a/src/melody/melody-code-frame/lineNumbers.js
+++ b/src/melody/melody-code-frame/lineNumbers.js
@@ -15,21 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { padStart } from 'lodash';
+import padStart from "lodash/padStart.js";
 
 const get = options => (key, defaultValue) =>
     key in options ? options[key] : defaultValue;
 
 function lineNumbers(lines, options) {
     const getOption = get(options);
-    const transform = getOption('transform', Function.prototype);
-    const padding = getOption('padding', ' ');
-    const before = getOption('before', ' ');
-    const after = getOption('after', ' | ');
-    const start = getOption('start', 1);
+    const transform = getOption("transform", Function.prototype);
+    const padding = getOption("padding", " ");
+    const before = getOption("before", " ");
+    const after = getOption("after", " | ");
+    const start = getOption("start", 1);
     const end = start + lines.length - 1;
     const width = String(end).length;
-    return lines.map(function(line, index) {
+    return lines.map((line, index) => {
         const number = start + index;
         const params = { before, number, width, after, line };
         transform(params);

--- a/src/melody/melody-extension-core/index.js
+++ b/src/melody/melody-extension-core/index.js
@@ -13,68 +13,68 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { unaryOperators, binaryOperators, tests } from './operators';
-import { AutoescapeParser } from './parser/autoescape';
-import { BlockParser } from './parser/block';
-import { DoParser } from './parser/do';
-import { EmbedParser } from './parser/embed';
-import { ExtendsParser } from './parser/extends';
-import { FilterParser } from './parser/filter';
-import { FlushParser } from './parser/flush';
-import { ForParser } from './parser/for';
-import { FromParser } from './parser/from';
-import { IfParser } from './parser/if';
-import { ImportParser } from './parser/import';
-import { IncludeParser } from './parser/include';
-import { MacroParser } from './parser/macro';
-import { SetParser } from './parser/set';
-import { SpacelessParser } from './parser/spaceless';
-import { UseParser } from './parser/use';
-import { MountParser } from './parser/mount';
+import { unaryOperators, binaryOperators, tests } from "./operators.js";
+import { AutoescapeParser } from "./parser/autoescape.js";
+import { BlockParser } from "./parser/block.js";
+import { DoParser } from "./parser/do.js";
+import { EmbedParser } from "./parser/embed.js";
+import { ExtendsParser } from "./parser/extends.js";
+import { FilterParser } from "./parser/filter.js";
+import { FlushParser } from "./parser/flush.js";
+import { ForParser } from "./parser/for.js";
+import { FromParser } from "./parser/from.js";
+import { IfParser } from "./parser/if.js";
+import { ImportParser } from "./parser/import.js";
+import { IncludeParser } from "./parser/include.js";
+import { MacroParser } from "./parser/macro.js";
+import { SetParser } from "./parser/set.js";
+import { SpacelessParser } from "./parser/spaceless.js";
+import { UseParser } from "./parser/use.js";
+import { MountParser } from "./parser/mount.js";
 
-import forVisitor from './visitors/for';
-import testVisitor from './visitors/tests';
-import filters from './visitors/filters';
-import functions from './visitors/functions';
+import forVisitor from "./visitors/for.js";
+import testVisitor from "./visitors/tests.js";
+import filters from "./visitors/filters.js";
+import functions from "./visitors/functions.js";
 
 const filterMap = [
-    'attrs',
-    'classes',
-    'styles',
-    'batch',
-    'escape',
-    'format',
-    'merge',
-    'nl2br',
-    'number_format',
-    'raw',
-    'replace',
-    'reverse',
-    'round',
-    'striptags',
-    'title',
-    'url_encode',
-    'trim',
+    "attrs",
+    "classes",
+    "styles",
+    "batch",
+    "escape",
+    "format",
+    "merge",
+    "nl2br",
+    "number_format",
+    "raw",
+    "replace",
+    "reverse",
+    "round",
+    "striptags",
+    "title",
+    "url_encode",
+    "trim"
 ].reduce((map, filterName) => {
-    map[filterName] = 'melody-runtime';
+    map[filterName] = "melody-runtime";
     return map;
 }, Object.create(null));
 
 Object.assign(filterMap, filters);
 
 const functionMap = [
-    'attribute',
-    'constant',
-    'cycle',
-    'date',
-    'max',
-    'min',
-    'random',
-    'range',
-    'source',
-    'template_from_string',
+    "attribute",
+    "constant",
+    "cycle",
+    "date",
+    "max",
+    "min",
+    "random",
+    "range",
+    "source",
+    "template_from_string"
 ].reduce((map, functionName) => {
-    map[functionName] = 'melody-runtime';
+    map[functionName] = "melody-runtime";
     return map;
 }, Object.create(null));
 Object.assign(functionMap, functions);
@@ -97,14 +97,14 @@ export const extension = {
         SetParser,
         SpacelessParser,
         UseParser,
-        MountParser,
+        MountParser
     ],
     unaryOperators,
     binaryOperators,
     tests,
     visitors: [forVisitor, testVisitor],
     filterMap,
-    functionMap,
+    functionMap
 };
 
 export {
@@ -163,5 +163,5 @@ export {
     TestDivisibleByExpression,
     TestConstantExpression,
     TestEmptyExpression,
-    TestIterableExpression,
-} from './types';
+    TestIterableExpression
+} from "./types.js";

--- a/src/melody/melody-extension-core/operators.js
+++ b/src/melody/melody-extension-core/operators.js
@@ -20,8 +20,9 @@ import {
     UnaryExpression,
     type,
     alias,
-    visitor,
-} from 'melody-types';
+    visitor
+} from "../melody-types/index.js";
+
 import {
     Types,
     setStartFromToken,
@@ -29,8 +30,8 @@ import {
     copyStart,
     copyEnd,
     copyLoc,
-    LEFT,
-} from 'melody-parser';
+    LEFT
+} from "../melody-parser/index.js";
 
 export const unaryOperators = [];
 export const binaryOperators = [];
@@ -38,144 +39,144 @@ export const tests = [];
 
 //region Unary Expressions
 export const UnaryNotExpression = createUnaryOperator(
-    'not',
-    'UnaryNotExpression',
+    "not",
+    "UnaryNotExpression",
     50
 );
 export const UnaryNeqExpression = createUnaryOperator(
-    '-',
-    'UnaryNeqExpression',
+    "-",
+    "UnaryNeqExpression",
     500
 );
 export const UnaryPosExpression = createUnaryOperator(
-    '+',
-    'UnaryPosExpression',
+    "+",
+    "UnaryPosExpression",
     500
 );
 //endregion
 
 //region Binary Expressions
 export const BinaryOrExpression = createBinaryOperatorNode({
-    text: 'or',
-    type: 'BinaryOrExpression',
+    text: "or",
+    type: "BinaryOrExpression",
     precedence: 10,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryAndExpression = createBinaryOperatorNode({
-    text: 'and',
-    type: 'BinaryAndExpression',
+    text: "and",
+    type: "BinaryAndExpression",
     precedence: 15,
-    associativity: LEFT,
+    associativity: LEFT
 });
 
 export const BitwiseOrExpression = createBinaryOperatorNode({
-    text: 'b-or',
-    type: 'BitwiseOrExpression',
+    text: "b-or",
+    type: "BitwiseOrExpression",
     precedence: 16,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BitwiseXorExpression = createBinaryOperatorNode({
-    text: 'b-xor',
-    type: 'BitwiseXOrExpression',
+    text: "b-xor",
+    type: "BitwiseXOrExpression",
     precedence: 17,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BitwiseAndExpression = createBinaryOperatorNode({
-    text: 'b-and',
-    type: 'BitwiseAndExpression',
+    text: "b-and",
+    type: "BitwiseAndExpression",
     precedence: 18,
-    associativity: LEFT,
+    associativity: LEFT
 });
 
 export const BinaryEqualsExpression = createBinaryOperatorNode({
-    text: '==',
-    type: 'BinaryEqualsExpression',
+    text: "==",
+    type: "BinaryEqualsExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryNotEqualsExpression = createBinaryOperatorNode({
-    text: '!=',
-    type: 'BinaryNotEqualsExpression',
+    text: "!=",
+    type: "BinaryNotEqualsExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryLessThanExpression = createBinaryOperatorNode({
-    text: '<',
-    type: 'BinaryLessThanExpression',
+    text: "<",
+    type: "BinaryLessThanExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryGreaterThanExpression = createBinaryOperatorNode({
-    text: '>',
-    type: 'BinaryGreaterThanExpression',
+    text: ">",
+    type: "BinaryGreaterThanExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryLessThanOrEqualExpression = createBinaryOperatorNode({
-    text: '<=',
-    type: 'BinaryLessThanOrEqualExpression',
+    text: "<=",
+    type: "BinaryLessThanOrEqualExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryGreaterThanOrEqualExpression = createBinaryOperatorNode({
-    text: '>=',
-    type: 'BinaryGreaterThanOrEqualExpression',
+    text: ">=",
+    type: "BinaryGreaterThanOrEqualExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 
 export const BinaryNotInExpression = createBinaryOperatorNode({
-    text: 'not in',
-    type: 'BinaryNotInExpression',
+    text: "not in",
+    type: "BinaryNotInExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryInExpression = createBinaryOperatorNode({
-    text: 'in',
-    type: 'BinaryInExpression',
+    text: "in",
+    type: "BinaryInExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryMatchesExpression = createBinaryOperatorNode({
-    text: 'matches',
-    type: 'BinaryMatchesExpression',
+    text: "matches",
+    type: "BinaryMatchesExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryStartsWithExpression = createBinaryOperatorNode({
-    text: 'starts with',
-    type: 'BinaryStartsWithExpression',
+    text: "starts with",
+    type: "BinaryStartsWithExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryEndsWithExpression = createBinaryOperatorNode({
-    text: 'ends with',
-    type: 'BinaryEndsWithExpression',
+    text: "ends with",
+    type: "BinaryEndsWithExpression",
     precedence: 20,
-    associativity: LEFT,
+    associativity: LEFT
 });
 
 export const BinaryRangeExpression = createBinaryOperatorNode({
-    text: '..',
-    type: 'BinaryRangeExpression',
+    text: "..",
+    type: "BinaryRangeExpression",
     precedence: 25,
-    associativity: LEFT,
+    associativity: LEFT
 });
 
 export const BinaryAddExpression = createBinaryOperatorNode({
-    text: '+',
-    type: 'BinaryAddExpression',
+    text: "+",
+    type: "BinaryAddExpression",
     precedence: 30,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinarySubExpression = createBinaryOperatorNode({
-    text: '-',
-    type: 'BinarySubExpression',
+    text: "-",
+    type: "BinarySubExpression",
     precedence: 30,
-    associativity: LEFT,
+    associativity: LEFT
 });
 binaryOperators.push({
-    text: '~',
+    text: "~",
     precedence: 40,
     associativity: LEFT,
     createNode(token, lhs, rhs) {
@@ -183,42 +184,42 @@ binaryOperators.push({
         copyStart(op, lhs);
         copyEnd(op, rhs);
         return op;
-    },
+    }
 });
 export const BinaryMulExpression = createBinaryOperatorNode({
-    text: '*',
-    type: 'BinaryMulExpression',
+    text: "*",
+    type: "BinaryMulExpression",
     precedence: 60,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryDivExpression = createBinaryOperatorNode({
-    text: '/',
-    type: 'BinaryDivExpression',
+    text: "/",
+    type: "BinaryDivExpression",
     precedence: 60,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryFloorDivExpression = createBinaryOperatorNode({
-    text: '//',
-    type: 'BinaryFloorDivExpression',
+    text: "//",
+    type: "BinaryFloorDivExpression",
     precedence: 60,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryModExpression = createBinaryOperatorNode({
-    text: '%',
-    type: 'BinaryModExpression',
+    text: "%",
+    type: "BinaryModExpression",
     precedence: 60,
-    associativity: LEFT,
+    associativity: LEFT
 });
 
 binaryOperators.push({
-    text: 'is',
+    text: "is",
     precedence: 100,
     associativity: LEFT,
     parse(parser, token, expr) {
         const tokens = parser.tokens;
 
         let not = false;
-        if (tokens.nextIf(Types.OPERATOR, 'not')) {
+        if (tokens.nextIf(Types.OPERATOR, "not")) {
             not = true;
         }
 
@@ -237,7 +238,7 @@ binaryOperators.push({
             );
         }
         return testExpression;
-    },
+    }
 });
 
 function getTest(parser) {
@@ -252,11 +253,11 @@ function getTest(parser) {
     if (!parser.hasTest(testName)) {
         // try 2-words tests
         const continuedNameToken = tokens.expect(Types.SYMBOL);
-        testName += ' ' + continuedNameToken.text;
+        testName += " " + continuedNameToken.text;
         if (!parser.hasTest(testName)) {
             parser.error({
                 title: `Unknown test "${testName}"`,
-                pos: nameToken.pos,
+                pos: nameToken.pos
             });
         }
     }
@@ -265,84 +266,88 @@ function getTest(parser) {
 }
 
 export const BinaryPowerExpression = createBinaryOperatorNode({
-    text: '**',
-    type: 'BinaryPowerExpression',
+    text: "**",
+    type: "BinaryPowerExpression",
     precedence: 200,
-    associativity: LEFT,
+    associativity: LEFT
 });
 export const BinaryNullCoalesceExpression = createBinaryOperatorNode({
-    text: '??',
-    type: 'BinaryNullCoalesceExpression',
+    text: "??",
+    type: "BinaryNullCoalesceExpression",
     precedence: 300,
-    associativity: LEFT,
+    associativity: LEFT
 });
 //endregion
 
 //region Test Expressions
-export const TestEvenExpression = createTest('even', 'TestEvenExpression');
-export const TestOddExpression = createTest('odd', 'TestOddExpression');
+export const TestEvenExpression = createTest("even", "TestEvenExpression");
+export const TestOddExpression = createTest("odd", "TestOddExpression");
 export const TestDefinedExpression = createTest(
-    'defined',
-    'TestDefinedExpression'
+    "defined",
+    "TestDefinedExpression"
 );
 export const TestSameAsExpression = createTest(
-    'same as',
-    'TestSameAsExpression'
+    "same as",
+    "TestSameAsExpression"
 );
 tests.push({
-    text: 'sameas',
+    text: "sameas",
     createNode(expr, args) {
         // todo: add deprecation warning
         return new TestSameAsExpression(expr, args);
-    },
+    }
 });
-export const TestNullExpression = createTest('null', 'TestNullExpression');
+export const TestNullExpression = createTest("null", "TestNullExpression");
 tests.push({
-    text: 'none',
+    text: "none",
     createNode(expr, args) {
         return new TestNullExpression(expr, args);
-    },
+    }
 });
 export const TestDivisibleByExpression = createTest(
-    'divisible by',
-    'TestDivisibleByExpression'
+    "divisible by",
+    "TestDivisibleByExpression"
 );
 tests.push({
-    text: 'divisibleby',
+    text: "divisibleby",
     createNode(expr, args) {
         // todo: add deprecation warning
         return new TestDivisibleByExpression(expr, args);
-    },
+    }
 });
 export const TestConstantExpression = createTest(
-    'constant',
-    'TestConstantExpression'
+    "constant",
+    "TestConstantExpression"
 );
-export const TestEmptyExpression = createTest('empty', 'TestEmptyExpression');
+export const TestEmptyExpression = createTest("empty", "TestEmptyExpression");
 export const TestIterableExpression = createTest(
-    'iterable',
-    'TestIterableExpression'
+    "iterable",
+    "TestIterableExpression"
 );
 //endregion
 
 //region Utilities
 function createTest(text, typeName) {
     const TestExpression = class extends Node {
-        constructor(expr: Node, args?: Array<Node>) {
+        /**
+         * @param {Node} expr
+         * @param {Array<Node>} [args]
+         */
+        constructor(expr, args) {
             super();
             this.expression = expr;
             this.arguments = args;
         }
     };
     type(TestExpression, typeName);
-    alias(TestExpression, 'Expression', 'TestExpression');
-    visitor(TestExpression, 'expression', 'arguments');
+    alias(TestExpression, "Expression", "TestExpression");
+    visitor(TestExpression, "expression", "arguments");
 
     tests.push({
         text,
         createNode(expr, args) {
             return new TestExpression(expr, args);
-        },
+        }
     });
 
     return TestExpression;
@@ -351,18 +356,22 @@ function createTest(text, typeName) {
 function createBinaryOperatorNode(options) {
     const { text, precedence, associativity } = options;
     const BinarySubclass = class extends BinaryExpression {
-        constructor(left: Node, right: Node) {
+        /**
+         * @param {Node} left
+         * @param {Node} right
+         */
+        constructor(left, right) {
             super(text, left, right);
         }
     };
     type(BinarySubclass, options.type);
-    alias(BinarySubclass, 'BinaryExpression', 'Binary', 'Expression');
-    visitor(BinarySubclass, 'left', 'right');
+    alias(BinarySubclass, "BinaryExpression", "Binary", "Expression");
+    visitor(BinarySubclass, "left", "right");
 
     const operator = {
         text,
         precedence,
-        associativity,
+        associativity
     };
     if (options.parse) {
         operator.parse = options.parse;
@@ -378,13 +387,16 @@ function createBinaryOperatorNode(options) {
 
 function createUnaryOperator(operator, typeName, precedence) {
     const UnarySubclass = class extends UnaryExpression {
-        constructor(argument: Node) {
+        /**
+         * @param {Node} argument
+         */
+        constructor(argument) {
             super(operator, argument);
         }
     };
     type(UnarySubclass, typeName);
-    alias(UnarySubclass, 'Expression', 'UnaryLike');
-    visitor(UnarySubclass, 'argument');
+    alias(UnarySubclass, "Expression", "UnaryLike");
+    visitor(UnarySubclass, "argument");
 
     unaryOperators.push({
         text: operator,
@@ -394,7 +406,7 @@ function createUnaryOperator(operator, typeName, precedence) {
             setStartFromToken(op, token);
             copyEnd(op, expr);
             return op;
-        },
+        }
     });
 
     return UnarySubclass;

--- a/src/melody/melody-extension-core/parser/autoescape.js
+++ b/src/melody/melody-extension-core/parser/autoescape.js
@@ -18,19 +18,20 @@ import {
     setStartFromToken,
     setEndFromToken,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { AutoescapeBlock } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+
+import { AutoescapeBlock } from "./../types.js";
 
 export const AutoescapeParser = {
-    name: 'autoescape',
+    name: "autoescape",
     parse(parser, token) {
         const tokens = parser.tokens;
 
-        let escapeType = null,
-            stringStartToken,
-            openingTagEndToken,
-            closingTagStartToken;
+        let escapeType = null;
+        let stringStartToken;
+        let openingTagEndToken;
+        let closingTagStartToken;
         if (tokens.nextIf(Types.TAG_END)) {
             openingTagEndToken = tokens.la(-1);
             escapeType = null;
@@ -38,14 +39,14 @@ export const AutoescapeParser = {
             escapeType = tokens.expect(Types.STRING).text;
             if (!tokens.nextIf(Types.STRING_END)) {
                 parser.error({
-                    title:
-                        'autoescape type declaration must be a simple string',
+                    title: "autoescape type declaration must be a simple string",
                     pos: tokens.la(0).pos,
                     advice: `The type declaration for autoescape must be a simple string such as 'html' or 'js'.
 I expected the current string to end with a ${
                         stringStartToken.text
-                    } but instead found ${Types.ERROR_TABLE[tokens.lat(0)] ||
-                        tokens.lat(0)}.`,
+                    } but instead found ${
+                        Types.ERROR_TABLE[tokens.lat(0)] || tokens.lat(0)
+                    }.`
                 });
             }
             openingTagEndToken = tokens.la(0);
@@ -57,11 +58,11 @@ I expected the current string to end with a ${
             openingTagEndToken = tokens.la(0);
         } else {
             parser.error({
-                title: 'Invalid autoescape type declaration',
+                title: "Invalid autoescape type declaration",
                 pos: tokens.la(0).pos,
                 advice: `Expected type of autoescape to be a string, boolean or not specified. Found ${
                     tokens.la(0).type
-                } instead.`,
+                } instead.`
             });
         }
 
@@ -71,7 +72,7 @@ I expected the current string to end with a ${
         autoescape.expressions = parser.parse((_, token, tokens) => {
             if (
                 token.type === Types.TAG_START &&
-                tokens.nextIf(Types.SYMBOL, 'endautoescape')
+                tokens.nextIf(Types.SYMBOL, "endautoescape")
             ) {
                 closingTagStartToken = token;
                 tagEndToken = tokens.expect(Types.TAG_END);
@@ -81,13 +82,11 @@ I expected the current string to end with a ${
         }).expressions;
         setEndFromToken(autoescape, tagEndToken);
 
-        autoescape.trimRightAutoescape = hasTagEndTokenTrimRight(
-            openingTagEndToken
-        );
-        autoescape.trimLeftEndautoescape = hasTagStartTokenTrimLeft(
-            closingTagStartToken
-        );
+        autoescape.trimRightAutoescape =
+            hasTagEndTokenTrimRight(openingTagEndToken);
+        autoescape.trimLeftEndautoescape =
+            hasTagStartTokenTrimLeft(closingTagStartToken);
 
         return autoescape;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/block.js
+++ b/src/melody/melody-extension-core/parser/block.js
@@ -13,31 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier, PrintExpressionStatement } from 'melody-types';
+import {
+    Identifier,
+    PrintExpressionStatement
+} from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     createNode,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { BlockStatement } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import { BlockStatement } from "./../types.js";
 
 export const BlockParser = {
-    name: 'block',
+    name: "block",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            nameToken = tokens.expect(Types.SYMBOL);
+        const tokens = parser.tokens;
+        const nameToken = tokens.expect(Types.SYMBOL);
 
-        let blockStatement, openingTagEndToken, closingTagStartToken;
+        let blockStatement;
+        let openingTagEndToken;
+        let closingTagStartToken;
         if ((openingTagEndToken = tokens.nextIf(Types.TAG_END))) {
             blockStatement = new BlockStatement(
                 createNode(Identifier, nameToken, nameToken.text),
                 parser.parse((tokenText, token, tokens) => {
                     const result = !!(
                         token.type === Types.TAG_START &&
-                        tokens.nextIf(Types.SYMBOL, 'endblock')
+                        tokens.nextIf(Types.SYMBOL, "endblock")
                     );
                     if (result) {
                         closingTagStartToken = token;
@@ -50,7 +55,7 @@ export const BlockParser = {
                 if (tokens.lat(0) !== Types.TAG_END) {
                     const unexpectedToken = tokens.next();
                     parser.error({
-                        title: 'Block name mismatch',
+                        title: "Block name mismatch",
                         pos: unexpectedToken.pos,
                         advice:
                             unexpectedToken.type == Types.SYMBOL
@@ -59,9 +64,10 @@ export const BlockParser = {
                                   } but instead found end of block ${
                                       tokens.la(0).text
                                   }.`
-                                : `endblock must be followed by either '%}' or the name of the open block. Found a token of type ${Types
-                                      .ERROR_TABLE[unexpectedToken.type] ||
-                                      unexpectedToken.type} instead.`,
+                                : `endblock must be followed by either '%}' or the name of the open block. Found a token of type ${
+                                      Types.ERROR_TABLE[unexpectedToken.type] ||
+                                      unexpectedToken.type
+                                  } instead.`
                     });
                 }
             }
@@ -83,5 +89,5 @@ export const BlockParser = {
         );
 
         return blockStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/do.js
+++ b/src/melody/melody-extension-core/parser/do.js
@@ -13,16 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
-import { DoStatement } from './../types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken
+} from "../../melody-parser/index.js";
+import { DoStatement } from "./../types.js";
 
 export const DoParser = {
-    name: 'do',
+    name: "do",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            doStatement = new DoStatement(parser.matchExpression());
+        const tokens = parser.tokens;
+        const doStatement = new DoStatement(parser.matchExpression());
         setStartFromToken(doStatement, token);
         setEndFromToken(doStatement, tokens.expect(Types.TAG_END));
         return doStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/embed.js
+++ b/src/melody/melody-extension-core/parser/embed.js
@@ -13,34 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Node } from 'melody-types';
+import { Node } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { filter } from 'lodash';
-import { EmbedStatement } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import filter from "lodash/filter.js";
+import { EmbedStatement } from "./../types.js";
 
 export const EmbedParser = {
-    name: 'embed',
+    name: "embed",
     parse(parser, token) {
         const tokens = parser.tokens;
 
         const embedStatement = new EmbedStatement(parser.matchExpression());
 
-        if (tokens.nextIf(Types.SYMBOL, 'ignore')) {
-            tokens.expect(Types.SYMBOL, 'missing');
+        if (tokens.nextIf(Types.SYMBOL, "ignore")) {
+            tokens.expect(Types.SYMBOL, "missing");
             embedStatement.ignoreMissing = true;
         }
 
-        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+        if (tokens.nextIf(Types.SYMBOL, "with")) {
             embedStatement.argument = parser.matchExpression();
         }
 
-        if (tokens.nextIf(Types.SYMBOL, 'only')) {
+        if (tokens.nextIf(Types.SYMBOL, "only")) {
             embedStatement.contextFree = true;
         }
 
@@ -52,7 +52,7 @@ export const EmbedParser = {
             parser.parse((tokenText, token, tokens) => {
                 const result = !!(
                     token.type === Types.TAG_START &&
-                    tokens.nextIf(Types.SYMBOL, 'endembed')
+                    tokens.nextIf(Types.SYMBOL, "endembed")
                 );
                 if (result) {
                     closingTagStartToken = token;
@@ -65,13 +65,12 @@ export const EmbedParser = {
         setStartFromToken(embedStatement, token);
         setEndFromToken(embedStatement, tokens.expect(Types.TAG_END));
 
-        embedStatement.trimRightEmbed = hasTagEndTokenTrimRight(
-            openingTagEndToken
-        );
+        embedStatement.trimRightEmbed =
+            hasTagEndTokenTrimRight(openingTagEndToken);
         embedStatement.trimLeftEndembed =
             closingTagStartToken &&
             hasTagStartTokenTrimLeft(closingTagStartToken);
 
         return embedStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/extends.js
+++ b/src/melody/melody-extension-core/parser/extends.js
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
-import { ExtendsStatement } from './../types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken
+} from "../../melody-parser/index.js";
+import { ExtendsStatement } from "./../types.js";
 
 export const ExtendsParser = {
-    name: 'extends',
+    name: "extends",
     parse(parser, token) {
         const tokens = parser.tokens;
 
@@ -27,5 +31,5 @@ export const ExtendsParser = {
         setEndFromToken(extendsStatement, tokens.expect(Types.TAG_END));
 
         return extendsStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/filter.js
+++ b/src/melody/melody-extension-core/parser/filter.js
@@ -13,23 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
+import { Identifier } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     createNode,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { FilterBlockStatement } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import { FilterBlockStatement } from "./../types.js";
 
 export const FilterParser = {
-    name: 'filter',
+    name: "filter",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            ref = createNode(Identifier, token, 'filter'),
-            filterExpression = parser.matchFilterExpression(ref);
+        const tokens = parser.tokens;
+        const ref = createNode(Identifier, token, "filter");
+        const filterExpression = parser.matchFilterExpression(ref);
         tokens.expect(Types.TAG_END);
         const openingTagEndToken = tokens.la(-1);
         let closingTagStartToken;
@@ -37,7 +37,7 @@ export const FilterParser = {
         const body = parser.parse((text, token, tokens) => {
             const result =
                 token.type === Types.TAG_START &&
-                tokens.nextIf(Types.SYMBOL, 'endfilter');
+                tokens.nextIf(Types.SYMBOL, "endfilter");
 
             if (result) {
                 closingTagStartToken = token;
@@ -52,13 +52,12 @@ export const FilterParser = {
         setStartFromToken(filterBlockStatement, token);
         setEndFromToken(filterBlockStatement, tokens.expect(Types.TAG_END));
 
-        filterBlockStatement.trimRightFilter = hasTagEndTokenTrimRight(
-            openingTagEndToken
-        );
+        filterBlockStatement.trimRightFilter =
+            hasTagEndTokenTrimRight(openingTagEndToken);
         filterBlockStatement.trimLeftEndfilter =
             closingTagStartToken &&
             hasTagStartTokenTrimLeft(closingTagStartToken);
 
         return filterBlockStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/flush.js
+++ b/src/melody/melody-extension-core/parser/flush.js
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
-import { FlushStatement } from './../types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken
+} from "../../melody-parser/index.js";
+import { FlushStatement } from "./../types.js";
 
 export const FlushParser = {
-    name: 'flush',
+    name: "flush",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            flushStatement = new FlushStatement();
+        const tokens = parser.tokens;
+        const flushStatement = new FlushStatement();
 
         setStartFromToken(flushStatement, token);
         setEndFromToken(flushStatement, tokens.expect(Types.TAG_END));
         return flushStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/for.js
+++ b/src/melody/melody-extension-core/parser/for.js
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
+import { Identifier } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     createNode,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { ForStatement } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import { ForStatement } from "./../types.js";
 
 export const ForParser = {
-    name: 'for',
+    name: "for",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            forStatement = new ForStatement();
+        const tokens = parser.tokens;
+        const forStatement = new ForStatement();
 
         const keyTarget = tokens.expect(Types.SYMBOL);
         if (tokens.nextIf(Types.COMMA)) {
@@ -52,44 +52,45 @@ export const ForParser = {
             );
         }
 
-        tokens.expect(Types.OPERATOR, 'in');
+        tokens.expect(Types.OPERATOR, "in");
 
         forStatement.sequence = parser.matchExpression();
 
-        if (tokens.nextIf(Types.SYMBOL, 'if')) {
+        if (tokens.nextIf(Types.SYMBOL, "if")) {
             forStatement.condition = parser.matchExpression();
         }
 
         tokens.expect(Types.TAG_END);
 
         const openingTagEndToken = tokens.la(-1);
-        let elseTagStartToken, elseTagEndToken;
+        let elseTagStartToken;
+        let elseTagEndToken;
 
         forStatement.body = parser.parse((tokenText, token, tokens) => {
             const result =
                 token.type === Types.TAG_START &&
-                (tokens.test(Types.SYMBOL, 'else') ||
-                    tokens.test(Types.SYMBOL, 'endfor'));
-            if (result && tokens.test(Types.SYMBOL, 'else')) {
+                (tokens.test(Types.SYMBOL, "else") ||
+                    tokens.test(Types.SYMBOL, "endfor"));
+            if (result && tokens.test(Types.SYMBOL, "else")) {
                 elseTagStartToken = token;
             }
             return result;
         });
 
-        if (tokens.nextIf(Types.SYMBOL, 'else')) {
+        if (tokens.nextIf(Types.SYMBOL, "else")) {
             tokens.expect(Types.TAG_END);
             elseTagEndToken = tokens.la(-1);
             forStatement.otherwise = parser.parse(
                 (tokenText, token, tokens) => {
                     return (
                         token.type === Types.TAG_START &&
-                        tokens.test(Types.SYMBOL, 'endfor')
+                        tokens.test(Types.SYMBOL, "endfor")
                     );
                 }
             );
         }
         const endforTagStartToken = tokens.la(-1);
-        tokens.expect(Types.SYMBOL, 'endfor');
+        tokens.expect(Types.SYMBOL, "endfor");
 
         setStartFromToken(forStatement, token);
         setEndFromToken(forStatement, tokens.expect(Types.TAG_END));
@@ -101,10 +102,9 @@ export const ForParser = {
         forStatement.trimRightElse = !!(
             elseTagEndToken && hasTagEndTokenTrimRight(elseTagEndToken)
         );
-        forStatement.trimLeftEndfor = hasTagStartTokenTrimLeft(
-            endforTagStartToken
-        );
+        forStatement.trimLeftEndfor =
+            hasTagStartTokenTrimLeft(endforTagStartToken);
 
         return forStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/from.js
+++ b/src/melody/melody-extension-core/parser/from.js
@@ -13,29 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
+import { Identifier } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
-    createNode,
-} from 'melody-parser';
-import { ImportDeclaration, FromStatement } from './../types';
+    createNode
+} from "../../melody-parser/index.js";
+import { ImportDeclaration, FromStatement } from "./../types.js";
 
 export const FromParser = {
-    name: 'from',
+    name: "from",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            source = parser.matchExpression(),
-            imports = [];
+        const tokens = parser.tokens;
+        const source = parser.matchExpression();
+        const imports = [];
 
-        tokens.expect(Types.SYMBOL, 'import');
+        tokens.expect(Types.SYMBOL, "import");
 
         do {
             const name = tokens.expect(Types.SYMBOL);
 
             let alias = name;
-            if (tokens.nextIf(Types.SYMBOL, 'as')) {
+            if (tokens.nextIf(Types.SYMBOL, "as")) {
                 alias = tokens.expect(Types.SYMBOL);
             }
 
@@ -59,5 +59,5 @@ export const FromParser = {
         setEndFromToken(fromStatement, tokens.expect(Types.TAG_END));
 
         return fromStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/if.js
+++ b/src/melody/melody-extension-core/parser/if.js
@@ -18,16 +18,16 @@ import {
     setStartFromToken,
     setEndFromToken,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { IfStatement } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import { IfStatement } from "./../types.js";
 
 export const IfParser = {
-    name: 'if',
+    name: "if",
     parse(parser, token) {
         const tokens = parser.tokens;
-        let test = parser.matchExpression(),
-            alternate = null;
+        let test = parser.matchExpression();
+        let alternate = null;
 
         tokens.expect(Types.TAG_END);
         const ifTagEndToken = tokens.la(-1);
@@ -37,37 +37,33 @@ export const IfParser = {
             parser.parse(matchConsequent).expressions
         );
 
-        let elseTagStartToken,
-            elseTagEndToken,
-            elseifTagStartToken,
-            elseifTagEndToken;
+        let elseTagStartToken;
+        let elseTagEndToken;
+        let elseifTagStartToken;
+        let elseifTagEndToken;
 
         do {
-            if (tokens.nextIf(Types.SYMBOL, 'else')) {
+            if (tokens.nextIf(Types.SYMBOL, "else")) {
                 elseTagStartToken = tokens.la(-2);
                 tokens.expect(Types.TAG_END);
                 elseTagEndToken = tokens.la(-1);
-                (alternate || ifStatement).alternate = parser.parse(
-                    matchAlternate
-                ).expressions;
-            } else if (tokens.nextIf(Types.SYMBOL, 'elseif')) {
+                (alternate || ifStatement).alternate =
+                    parser.parse(matchAlternate).expressions;
+            } else if (tokens.nextIf(Types.SYMBOL, "elseif")) {
                 elseifTagStartToken = tokens.la(-2);
                 test = parser.matchExpression();
                 tokens.expect(Types.TAG_END);
                 elseifTagEndToken = tokens.la(-1);
                 const consequent = parser.parse(matchConsequent).expressions;
-                alternate = (
-                    alternate || ifStatement
-                ).alternate = new IfStatement(test, consequent);
-                alternate.trimLeft = hasTagStartTokenTrimLeft(
-                    elseifTagStartToken
-                );
-                alternate.trimRightIf = hasTagEndTokenTrimRight(
-                    elseifTagEndToken
-                );
+                alternate = (alternate || ifStatement).alternate =
+                    new IfStatement(test, consequent);
+                alternate.trimLeft =
+                    hasTagStartTokenTrimLeft(elseifTagStartToken);
+                alternate.trimRightIf =
+                    hasTagEndTokenTrimRight(elseifTagEndToken);
             }
 
-            if (tokens.nextIf(Types.SYMBOL, 'endif')) {
+            if (tokens.nextIf(Types.SYMBOL, "endif")) {
                 break;
             }
         } while (!tokens.test(Types.EOF));
@@ -84,22 +80,21 @@ export const IfParser = {
         ifStatement.trimRightElse = !!(
             elseTagEndToken && hasTagEndTokenTrimRight(elseTagEndToken)
         );
-        ifStatement.trimLeftEndif = hasTagStartTokenTrimLeft(
-            endifTagStartToken
-        );
+        ifStatement.trimLeftEndif =
+            hasTagStartTokenTrimLeft(endifTagStartToken);
 
         return ifStatement;
-    },
+    }
 };
 
 function matchConsequent(tokenText, token, tokens) {
     if (token.type === Types.TAG_START) {
         const next = tokens.la(0).text;
-        return next === 'else' || next === 'endif' || next === 'elseif';
+        return next === "else" || next === "endif" || next === "elseif";
     }
     return false;
 }
 
 function matchAlternate(tokenText, token, tokens) {
-    return token.type === Types.TAG_START && tokens.test(Types.SYMBOL, 'endif');
+    return token.type === Types.TAG_START && tokens.test(Types.SYMBOL, "endif");
 }

--- a/src/melody/melody-extension-core/parser/import.js
+++ b/src/melody/melody-extension-core/parser/import.js
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
+import { Identifier } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
-    createNode,
-} from 'melody-parser';
-import { ImportDeclaration } from './../types';
+    createNode
+} from "../../melody-parser/index.js";
+import { ImportDeclaration } from "./../types.js";
 
 export const ImportParser = {
-    name: 'import',
+    name: "import",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            source = parser.matchExpression();
+        const tokens = parser.tokens;
+        const source = parser.matchExpression();
 
-        tokens.expect(Types.SYMBOL, 'as');
+        tokens.expect(Types.SYMBOL, "as");
         const alias = tokens.expect(Types.SYMBOL);
 
         const importStatement = new ImportDeclaration(
@@ -40,5 +40,5 @@ export const ImportParser = {
         setEndFromToken(importStatement, tokens.expect(Types.TAG_END));
 
         return importStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/include.js
+++ b/src/melody/melody-extension-core/parser/include.js
@@ -13,26 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
-import { IncludeStatement } from './../types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken
+} from "../../melody-parser/index.js";
+import { IncludeStatement } from "./../types.js";
 
 export const IncludeParser = {
-    name: 'include',
+    name: "include",
     parse(parser, token) {
         const tokens = parser.tokens;
 
         const includeStatement = new IncludeStatement(parser.matchExpression());
 
-        if (tokens.nextIf(Types.SYMBOL, 'ignore')) {
-            tokens.expect(Types.SYMBOL, 'missing');
+        if (tokens.nextIf(Types.SYMBOL, "ignore")) {
+            tokens.expect(Types.SYMBOL, "missing");
             includeStatement.ignoreMissing = true;
         }
 
-        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+        if (tokens.nextIf(Types.SYMBOL, "with")) {
             includeStatement.argument = parser.matchExpression();
         }
 
-        if (tokens.nextIf(Types.SYMBOL, 'only')) {
+        if (tokens.nextIf(Types.SYMBOL, "only")) {
             includeStatement.contextFree = true;
         }
 
@@ -40,5 +44,5 @@ export const IncludeParser = {
         setEndFromToken(includeStatement, tokens.expect(Types.TAG_END));
 
         return includeStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/macro.js
+++ b/src/melody/melody-extension-core/parser/macro.js
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
+import { Identifier } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     createNode,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { MacroDeclarationStatement } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import { MacroDeclarationStatement } from "./../types.js";
 
 export const MacroParser = {
-    name: 'macro',
+    name: "macro",
     parse(parser, token) {
         const tokens = parser.tokens;
 
@@ -42,8 +42,7 @@ export const MacroParser = {
                 parser.error({
                     title: 'Expected comma or ")"',
                     pos: tokens.la(0).pos,
-                    advice:
-                        'The argument list of a macro can only consist of parameter names separated by commas.',
+                    advice: "The argument list of a macro can only consist of parameter names separated by commas."
                 });
             }
         }
@@ -55,7 +54,7 @@ export const MacroParser = {
         const body = parser.parse((tokenText, token, tokens) => {
             const result = !!(
                 token.type === Types.TAG_START &&
-                tokens.nextIf(Types.SYMBOL, 'endmacro')
+                tokens.nextIf(Types.SYMBOL, "endmacro")
             );
             if (result) {
                 closingTagStartToken = token;
@@ -64,13 +63,11 @@ export const MacroParser = {
         });
 
         if (tokens.test(Types.SYMBOL)) {
-            var nameEndToken = tokens.next();
+            const nameEndToken = tokens.next();
             if (nameToken.text !== nameEndToken.text) {
                 parser.error({
-                    title: `Macro name mismatch, expected "${
-                        nameToken.text
-                    }" but found "${nameEndToken.text}"`,
-                    pos: nameEndToken.pos,
+                    title: `Macro name mismatch, expected "${nameToken.text}" but found "${nameEndToken.text}"`,
+                    pos: nameEndToken.pos
                 });
             }
         }
@@ -87,13 +84,11 @@ export const MacroParser = {
             tokens.expect(Types.TAG_END)
         );
 
-        macroDeclarationStatement.trimRightMacro = hasTagEndTokenTrimRight(
-            openingTagEndToken
-        );
-        macroDeclarationStatement.trimLeftEndmacro = hasTagStartTokenTrimLeft(
-            closingTagStartToken
-        );
+        macroDeclarationStatement.trimRightMacro =
+            hasTagEndTokenTrimRight(openingTagEndToken);
+        macroDeclarationStatement.trimLeftEndmacro =
+            hasTagStartTokenTrimLeft(closingTagStartToken);
 
         return macroDeclarationStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/mount.js
+++ b/src/melody/melody-extension-core/parser/mount.js
@@ -13,30 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
-import { MountStatement } from '../types';
+import { Identifier } from "../../melody-types/index.js";
+import { MountStatement } from "../types.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     createNode,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
 
 export const MountParser = {
-    name: 'mount',
+    name: "mount",
     parse(parser, token) {
         const tokens = parser.tokens;
 
-        let name = null,
-            source = null,
-            key = null,
-            async = false,
-            delayBy = 0,
-            argument = null;
+        let name = null;
+        let source = null;
+        let key = null;
+        let async = false;
+        let delayBy = 0;
+        let argument = null;
 
-        if (tokens.test(Types.SYMBOL, 'async')) {
+        if (tokens.test(Types.SYMBOL, "async")) {
             // we might be looking at an async mount
             const nextToken = tokens.la(1);
             if (nextToken.type === Types.STRING_START) {
@@ -50,28 +50,28 @@ export const MountParser = {
         } else {
             const nameToken = tokens.expect(Types.SYMBOL);
             name = createNode(Identifier, nameToken, nameToken.text);
-            if (tokens.nextIf(Types.SYMBOL, 'from')) {
+            if (tokens.nextIf(Types.SYMBOL, "from")) {
                 source = parser.matchStringExpression();
             }
         }
 
-        if (tokens.nextIf(Types.SYMBOL, 'as')) {
+        if (tokens.nextIf(Types.SYMBOL, "as")) {
             key = parser.matchExpression();
         }
 
-        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+        if (tokens.nextIf(Types.SYMBOL, "with")) {
             argument = parser.matchExpression();
         }
 
         if (async) {
-            if (tokens.nextIf(Types.SYMBOL, 'delay')) {
-                tokens.expect(Types.SYMBOL, 'placeholder');
-                tokens.expect(Types.SYMBOL, 'by');
+            if (tokens.nextIf(Types.SYMBOL, "delay")) {
+                tokens.expect(Types.SYMBOL, "placeholder");
+                tokens.expect(Types.SYMBOL, "by");
                 delayBy = Number.parseInt(tokens.expect(Types.NUMBER).text, 10);
-                if (tokens.nextIf(Types.SYMBOL, 's')) {
+                if (tokens.nextIf(Types.SYMBOL, "s")) {
                     delayBy *= 1000;
                 } else {
-                    tokens.expect(Types.SYMBOL, 'ms');
+                    tokens.expect(Types.SYMBOL, "ms");
                 }
             }
         }
@@ -85,10 +85,10 @@ export const MountParser = {
             delayBy
         );
 
-        let openingTagEndToken,
-            catchTagStartToken,
-            catchTagEndToken,
-            endmountTagStartToken;
+        let openingTagEndToken;
+        let catchTagStartToken;
+        let catchTagEndToken;
+        let endmountTagStartToken;
 
         if (async) {
             tokens.expect(Types.TAG_END);
@@ -97,12 +97,12 @@ export const MountParser = {
             mountStatement.body = parser.parse((tokenText, token, tokens) => {
                 return (
                     token.type === Types.TAG_START &&
-                    (tokens.test(Types.SYMBOL, 'catch') ||
-                        tokens.test(Types.SYMBOL, 'endmount'))
+                    (tokens.test(Types.SYMBOL, "catch") ||
+                        tokens.test(Types.SYMBOL, "endmount"))
                 );
             });
 
-            if (tokens.nextIf(Types.SYMBOL, 'catch')) {
+            if (tokens.nextIf(Types.SYMBOL, "catch")) {
                 catchTagStartToken = tokens.la(-2);
                 const errorVariableName = tokens.expect(Types.SYMBOL);
                 mountStatement.errorVariableName = createNode(
@@ -116,12 +116,12 @@ export const MountParser = {
                     (tokenText, token, tokens) => {
                         return (
                             token.type === Types.TAG_START &&
-                            tokens.test(Types.SYMBOL, 'endmount')
+                            tokens.test(Types.SYMBOL, "endmount")
                         );
                     }
                 );
             }
-            tokens.expect(Types.SYMBOL, 'endmount');
+            tokens.expect(Types.SYMBOL, "endmount");
             endmountTagStartToken = tokens.la(-2);
         }
 
@@ -143,5 +143,5 @@ export const MountParser = {
         );
 
         return mountStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/set.js
+++ b/src/melody/melody-extension-core/parser/set.js
@@ -13,25 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
+import { Identifier } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     createNode,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { VariableDeclarationStatement, SetStatement } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import { VariableDeclarationStatement, SetStatement } from "./../types.js";
 
 export const SetParser = {
-    name: 'set',
+    name: "set",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            names = [],
-            values = [];
+        const tokens = parser.tokens;
+        const names = [];
+        const values = [];
 
-        let openingTagEndToken, closingTagStartToken;
+        let openingTagEndToken;
+        let closingTagStartToken;
 
         do {
             const name = tokens.expect(Types.SYMBOL);
@@ -45,10 +46,9 @@ export const SetParser = {
         } else {
             if (names.length !== 1) {
                 parser.error({
-                    title: 'Illegal multi-set',
+                    title: "Illegal multi-set",
                     pos: tokens.la(0).pos,
-                    advice:
-                        'When using set with a block, you cannot have multiple targets.',
+                    advice: "When using set with a block, you cannot have multiple targets."
                 });
             }
             tokens.expect(Types.TAG_END);
@@ -57,7 +57,7 @@ export const SetParser = {
             values[0] = parser.parse((tokenText, token, tokens) => {
                 const result = !!(
                     token.type === Types.TAG_START &&
-                    tokens.nextIf(Types.SYMBOL, 'endset')
+                    tokens.nextIf(Types.SYMBOL, "endset")
                 );
                 if (result) {
                     closingTagStartToken = token;
@@ -68,11 +68,11 @@ export const SetParser = {
 
         if (names.length !== values.length) {
             parser.error({
-                title: 'Mismatch of set names and values',
+                title: "Mismatch of set names and values",
                 pos: token.pos,
                 advice: `When using set, you must ensure that the number of
 assigned variable names is identical to the supplied values. However, here I've found
-${names.length} variable names and ${values.length} values.`,
+${names.length} variable names and ${values.length} values.`
             });
         }
 
@@ -99,5 +99,5 @@ ${names.length} variable names and ${values.length} values.`,
         );
 
         return setStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/spaceless.js
+++ b/src/melody/melody-extension-core/parser/spaceless.js
@@ -18,12 +18,12 @@ import {
     setStartFromToken,
     setEndFromToken,
     hasTagStartTokenTrimLeft,
-    hasTagEndTokenTrimRight,
-} from 'melody-parser';
-import { SpacelessBlock } from './../types';
+    hasTagEndTokenTrimRight
+} from "../../melody-parser/index.js";
+import { SpacelessBlock } from "./../types.js";
 
 export const SpacelessParser = {
-    name: 'spaceless',
+    name: "spaceless",
     parse(parser, token) {
         const tokens = parser.tokens;
 
@@ -34,7 +34,7 @@ export const SpacelessParser = {
         const body = parser.parse((tokenText, token, tokens) => {
             const result = !!(
                 token.type === Types.TAG_START &&
-                tokens.nextIf(Types.SYMBOL, 'endspaceless')
+                tokens.nextIf(Types.SYMBOL, "endspaceless")
             );
             closingTagStartToken = token;
             return result;
@@ -44,14 +44,13 @@ export const SpacelessParser = {
         setStartFromToken(spacelessBlock, token);
         setEndFromToken(spacelessBlock, tokens.expect(Types.TAG_END));
 
-        spacelessBlock.trimRightSpaceless = hasTagEndTokenTrimRight(
-            openingTagEndToken
-        );
+        spacelessBlock.trimRightSpaceless =
+            hasTagEndTokenTrimRight(openingTagEndToken);
         spacelessBlock.trimLeftEndspaceless = !!(
             closingTagStartToken &&
             hasTagStartTokenTrimLeft(closingTagStartToken)
         );
 
         return spacelessBlock;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/parser/use.js
+++ b/src/melody/melody-extension-core/parser/use.js
@@ -13,31 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Identifier } from 'melody-types';
+import { Identifier } from "../../melody-types/index.js";
 import {
     Types,
     setStartFromToken,
     setEndFromToken,
     copyStart,
     copyEnd,
-    createNode,
-} from 'melody-parser';
-import { AliasExpression, UseStatement } from './../types';
+    createNode
+} from "../../melody-parser/index.js";
+import { AliasExpression, UseStatement } from "./../types.js";
 
 export const UseParser = {
-    name: 'use',
+    name: "use",
     parse(parser, token) {
         const tokens = parser.tokens;
 
-        const source = parser.matchExpression(),
-            aliases = [];
+        const source = parser.matchExpression();
+        const aliases = [];
 
-        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+        if (tokens.nextIf(Types.SYMBOL, "with")) {
             do {
-                const nameToken = tokens.expect(Types.SYMBOL),
-                    name = createNode(Identifier, nameToken, nameToken.text);
+                const nameToken = tokens.expect(Types.SYMBOL);
+                const name = createNode(Identifier, nameToken, nameToken.text);
                 let alias = name;
-                if (tokens.nextIf(Types.SYMBOL, 'as')) {
+                if (tokens.nextIf(Types.SYMBOL, "as")) {
                     const aliasToken = tokens.expect(Types.SYMBOL);
                     alias = createNode(Identifier, aliasToken, aliasToken.text);
                 }
@@ -54,5 +54,5 @@ export const UseParser = {
         setEndFromToken(useStatement, tokens.expect(Types.TAG_END));
 
         return useStatement;
-    },
+    }
 };

--- a/src/melody/melody-extension-core/types.js
+++ b/src/melody/melody-extension-core/types.js
@@ -20,51 +20,67 @@ import {
     type,
     alias,
     visitor,
-} from 'melody-types';
-import type { StringLiteral } from 'melody-types';
+    StringLiteral
+} from "../melody-types/index.js";
 
 export class AutoescapeBlock extends Node {
-    constructor(type: String | boolean, expressions?: Array<Node>) {
+    /**
+     *
+     * @param {String | boolean} type
+     * @param {Array<Node>} [expressions]
+     */
+    constructor(type, expressions = []) {
         super();
         this.escapeType = type;
         this.expressions = expressions;
     }
 }
-type(AutoescapeBlock, 'AutoescapeBlock');
-alias(AutoescapeBlock, 'Block', 'Escape');
-visitor(AutoescapeBlock, 'expressions');
+type(AutoescapeBlock, "AutoescapeBlock");
+alias(AutoescapeBlock, "Block", "Escape");
+visitor(AutoescapeBlock, "expressions");
 
 export class BlockStatement extends Node {
-    constructor(name: Identifier, body: Node) {
+    /**
+     * @param {Identifier} name
+     * @param {Node} body
+     */
+    constructor(name, body) {
         super();
         this.name = name;
         this.body = body;
     }
 }
-type(BlockStatement, 'BlockStatement');
-alias(BlockStatement, 'Statement', 'Scope', 'RootScope');
-visitor(BlockStatement, 'body');
+type(BlockStatement, "BlockStatement");
+alias(BlockStatement, "Statement", "Scope", "RootScope");
+visitor(BlockStatement, "body");
 
 export class BlockCallExpression extends Node {
-    constructor(callee: StringLiteral, args: Array<Node> = []) {
+    /**
+     * @param {StringLiteral} callee
+     * @param {Array<Node>} args
+     */
+    constructor(callee, args = []) {
         super();
         this.callee = callee;
         this.arguments = args;
     }
 }
-type(BlockCallExpression, 'BlockCallExpression');
-alias(BlockCallExpression, 'Expression', 'FunctionInvocation');
-visitor(BlockCallExpression, 'arguments');
+type(BlockCallExpression, "BlockCallExpression");
+alias(BlockCallExpression, "Expression", "FunctionInvocation");
+visitor(BlockCallExpression, "arguments");
 
 export class MountStatement extends Node {
-    constructor(
-        name?: Identifier,
-        source?: String,
-        key?: Node,
-        argument?: Node,
-        async?: Boolean,
-        delayBy?: Number
-    ) {
+    /**
+     * Constructs an instance with the given parameters.
+     *
+     * @param {Identifier} [name]
+     * @param {string} [source]
+     * @param {Node} [key]
+     * @param {Node} [argument]
+     * @param {boolean} [async]
+     * @param {number} [delayBy]
+     */
+    constructor(name, source, key, argument, async, delayBy) {
         super();
         this.name = name;
         this.source = source;
@@ -77,30 +93,36 @@ export class MountStatement extends Node {
         this.otherwise = null;
     }
 }
-type(MountStatement, 'MountStatement');
-alias(MountStatement, 'Statement', 'Scope');
+type(MountStatement, "MountStatement");
+alias(MountStatement, "Statement", "Scope");
 visitor(
     MountStatement,
-    'name',
-    'source',
-    'key',
-    'argument',
-    'body',
-    'otherwise'
+    "name",
+    "source",
+    "key",
+    "argument",
+    "body",
+    "otherwise"
 );
 
 export class DoStatement extends Node {
-    constructor(expression: Node) {
+    /**
+     * @param {Node} expression
+     */
+    constructor(expression) {
         super();
         this.value = expression;
     }
 }
-type(DoStatement, 'DoStatement');
-alias(DoStatement, 'Statement');
-visitor(DoStatement, 'value');
+type(DoStatement, "DoStatement");
+alias(DoStatement, "Statement");
+visitor(DoStatement, "value");
 
 export class EmbedStatement extends Node {
-    constructor(parent: Node) {
+    /**
+     * @param {Node} parent
+     */
+    constructor(parent) {
         super();
         this.parent = parent;
         this.argument = null;
@@ -110,47 +132,62 @@ export class EmbedStatement extends Node {
         this.blocks = null;
     }
 }
-type(EmbedStatement, 'EmbedStatement');
-alias(EmbedStatement, 'Statement', 'Include');
-visitor(EmbedStatement, 'argument', 'blocks');
+type(EmbedStatement, "EmbedStatement");
+alias(EmbedStatement, "Statement", "Include");
+visitor(EmbedStatement, "argument", "blocks");
 
 export class ExtendsStatement extends Node {
-    constructor(parentName: Node) {
+    /**
+     * @param {Node} parentName
+     */
+    constructor(parentName) {
         super();
         this.parentName = parentName;
     }
 }
-type(ExtendsStatement, 'ExtendsStatement');
-alias(ExtendsStatement, 'Statement', 'Include');
-visitor(ExtendsStatement, 'parentName');
+type(ExtendsStatement, "ExtendsStatement");
+alias(ExtendsStatement, "Statement", "Include");
+visitor(ExtendsStatement, "parentName");
 
 export class FilterBlockStatement extends Node {
-    constructor(filterExpression: Node, body: Node) {
+    /**
+     * @param {Node} filterExpression
+     * @param {Node} body
+     */
+    constructor(filterExpression, body) {
         super();
         this.filterExpression = filterExpression;
         this.body = body;
     }
 }
-type(FilterBlockStatement, 'FilterBlockStatement');
-alias(FilterBlockStatement, 'Statement', 'Block');
-visitor(FilterBlockStatement, 'filterExpression', 'body');
+type(FilterBlockStatement, "FilterBlockStatement");
+alias(FilterBlockStatement, "Statement", "Block");
+visitor(FilterBlockStatement, "filterExpression", "body");
 
 export class FlushStatement extends Node {
     constructor() {
         super();
     }
 }
-type(FlushStatement, 'FlushStatement');
-alias(FlushStatement, 'Statement');
+type(FlushStatement, "FlushStatement");
+alias(FlushStatement, "Statement");
 
 export class ForStatement extends Node {
+    /**
+     * @param {Identifier} keyTarget
+     * @param {Identifier} valueTarget
+     * @param {Node} sequence
+     * @param {Node} condition
+     * @param {Node} body
+     * @param {Node} otherwise
+     */
     constructor(
-        keyTarget?: Identifier = null,
-        valueTarget?: Identifier = null,
-        sequence?: Node = null,
-        condition?: Node = null,
-        body?: Node = null,
-        otherwise?: Node = null
+        keyTarget = null,
+        valueTarget = null,
+        sequence = null,
+        condition = null,
+        body = null,
+        otherwise = null
     ) {
         super();
         this.keyTarget = keyTarget;
@@ -161,54 +198,70 @@ export class ForStatement extends Node {
         this.otherwise = otherwise;
     }
 }
-type(ForStatement, 'ForStatement');
-alias(ForStatement, 'Statement', 'Scope', 'Loop');
+type(ForStatement, "ForStatement");
+alias(ForStatement, "Statement", "Scope", "Loop");
 visitor(
     ForStatement,
-    'keyTarget',
-    'valueTarget',
-    'sequence',
-    'condition',
-    'body',
-    'otherwise'
+    "keyTarget",
+    "valueTarget",
+    "sequence",
+    "condition",
+    "body",
+    "otherwise"
 );
 
 export class ImportDeclaration extends Node {
-    constructor(key: Node, alias: Identifier) {
+    /**
+     * @param {Node} key
+     * @param {Identifier} alias
+     */
+    constructor(key, alias) {
         super();
         this.key = key;
         this.alias = alias;
     }
 }
-type(ImportDeclaration, 'ImportDeclaration');
-alias(ImportDeclaration, 'VariableDeclaration');
-visitor(ImportDeclaration, 'key', 'value');
+type(ImportDeclaration, "ImportDeclaration");
+alias(ImportDeclaration, "VariableDeclaration");
+visitor(ImportDeclaration, "key", "value");
 
 export class FromStatement extends Node {
-    constructor(source: Node, imports: Array<ImportDeclaration>) {
+    /**
+     * @param {Node} source
+     * @param {Array<ImportDeclaration>} imports
+     */
+    constructor(source, imports) {
         super();
         this.source = source;
         this.imports = imports;
     }
 }
-type(FromStatement, 'FromStatement');
-alias(FromStatement, 'Statement');
-visitor(FromStatement, 'source', 'imports');
+type(FromStatement, "FromStatement");
+alias(FromStatement, "Statement");
+visitor(FromStatement, "source", "imports");
 
 export class IfStatement extends Node {
-    constructor(test: Node, consequent?: Node = null, alternate?: Node = null) {
+    /**
+     * @param {Node} test
+     * @param {Node} [consequent]
+     * @param {Node} [alternate]
+     */
+    constructor(test, consequent = null, alternate = null) {
         super();
         this.test = test;
         this.consequent = consequent;
         this.alternate = alternate;
     }
 }
-type(IfStatement, 'IfStatement');
-alias(IfStatement, 'Statement', 'Conditional');
-visitor(IfStatement, 'test', 'consequent', 'alternate');
+type(IfStatement, "IfStatement");
+alias(IfStatement, "Statement", "Conditional");
+visitor(IfStatement, "test", "consequent", "alternate");
 
 export class IncludeStatement extends Node {
-    constructor(source: Node) {
+    /**
+     * @param {Node} source
+     */
+    constructor(source) {
         super();
         this.source = source;
         this.argument = null;
@@ -217,74 +270,97 @@ export class IncludeStatement extends Node {
         this.ignoreMissing = false;
     }
 }
-type(IncludeStatement, 'IncludeStatement');
-alias(IncludeStatement, 'Statement', 'Include');
-visitor(IncludeStatement, 'source', 'argument');
+type(IncludeStatement, "IncludeStatement");
+alias(IncludeStatement, "Statement", "Include");
+visitor(IncludeStatement, "source", "argument");
 
 export class MacroDeclarationStatement extends Node {
-    constructor(name: Identifier, args: Array<Node>, body: SequenceExpression) {
+    /**
+     * @param {Identifier} name
+     * @param {Array<Node>} args
+     * @param {SequenceExpression} body
+     */
+    constructor(name, args, body) {
         super();
         this.name = name;
         this.arguments = args;
         this.body = body;
     }
 }
-type(MacroDeclarationStatement, 'MacroDeclarationStatement');
-alias(MacroDeclarationStatement, 'Statement', 'Scope', 'RootScope');
-visitor(MacroDeclarationStatement, 'name', 'arguments', 'body');
+type(MacroDeclarationStatement, "MacroDeclarationStatement");
+alias(MacroDeclarationStatement, "Statement", "Scope", "RootScope");
+visitor(MacroDeclarationStatement, "name", "arguments", "body");
 
 export class VariableDeclarationStatement extends Node {
-    constructor(name: Identifier, value: Node) {
+    /**
+     * @param {Identifier} name
+     * @param {Node} value
+     */
+    constructor(name, value) {
         super();
         this.name = name;
         this.value = value;
     }
 }
-type(VariableDeclarationStatement, 'VariableDeclarationStatement');
-alias(VariableDeclarationStatement, 'Statement');
-visitor(VariableDeclarationStatement, 'name', 'value');
+type(VariableDeclarationStatement, "VariableDeclarationStatement");
+alias(VariableDeclarationStatement, "Statement");
+visitor(VariableDeclarationStatement, "name", "value");
 
 export class SetStatement extends Node {
-    constructor(assignments: Array<VariableDeclarationStatement>) {
+    /**
+     * @param {Array<VariableDeclarationStatement>} assignments
+     */
+    constructor(assignments) {
         super();
         this.assignments = assignments;
     }
 }
-type(SetStatement, 'SetStatement');
-alias(SetStatement, 'Statement', 'ContextMutation');
-visitor(SetStatement, 'assignments');
+type(SetStatement, "SetStatement");
+alias(SetStatement, "Statement", "ContextMutation");
+visitor(SetStatement, "assignments");
 
 export class SpacelessBlock extends Node {
-    constructor(body?: Node = null) {
+    /**
+     * @param {Node} [body]
+     */
+    constructor(body = null) {
         super();
         this.body = body;
     }
 }
-type(SpacelessBlock, 'SpacelessBlock');
-alias(SpacelessBlock, 'Statement', 'Block');
-visitor(SpacelessBlock, 'body');
+type(SpacelessBlock, "SpacelessBlock");
+alias(SpacelessBlock, "Statement", "Block");
+visitor(SpacelessBlock, "body");
 
 export class AliasExpression extends Node {
-    constructor(name: Identifier, alias: Identifier) {
+    /**
+     * @param {Identifier} name
+     * @param {Identifier} alias
+     */
+    constructor(name, alias) {
         super();
         this.name = name;
         this.alias = alias;
     }
 }
-type(AliasExpression, 'AliasExpression');
-alias(AliasExpression, 'Expression');
-visitor(AliasExpression, 'name', 'alias');
+type(AliasExpression, "AliasExpression");
+alias(AliasExpression, "Expression");
+visitor(AliasExpression, "name", "alias");
 
 export class UseStatement extends Node {
-    constructor(source: Node, aliases: Array<AliasExpression>) {
+    /**
+     * @param {Node} source
+     * @param {Array<AliasExpression>} aliases
+     */
+    constructor(source, aliases) {
         super();
         this.source = source;
         this.aliases = aliases;
     }
 }
-type(UseStatement, 'UseStatement');
-alias(UseStatement, 'Statement', 'Include');
-visitor(UseStatement, 'source', 'aliases');
+type(UseStatement, "UseStatement");
+alias(UseStatement, "Statement", "Include");
+visitor(UseStatement, "source", "aliases");
 
 export {
     UnaryNotExpression,
@@ -322,5 +398,5 @@ export {
     TestDivisibleByExpression,
     TestConstantExpression,
     TestEmptyExpression,
-    TestIterableExpression,
-} from './operators';
+    TestIterableExpression
+} from "./operators.js";

--- a/src/melody/melody-extension-core/visitors/filters.js
+++ b/src/melody/melody-extension-core/visitors/filters.js
@@ -13,25 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as t from 'babel-types';
-import template from 'babel-template';
+import * as t from "babel-types";
+import template from "babel-template";
 
 // use default value if var is null, undefined or an empty string
 // but use var if value is 0, false, an empty array or an empty object
 const defaultFilter = template("VAR != null && VAR !== '' ? VAR : DEFAULT");
 
 export default {
-    capitalize: 'lodash',
-    first: 'lodash',
-    last: 'lodash',
-    keys: 'lodash',
+    capitalize: "lodash",
+    first: "lodash",
+    last: "lodash",
+    keys: "lodash",
     default(path) {
         // babel-template transforms it to an expression statement
         // but we really need an expression here, so unwrap it
         path.replaceWithJS(
             defaultFilter({
                 VAR: path.node.target,
-                DEFAULT: path.node.arguments[0] || t.stringLiteral(''),
+                DEFAULT: path.node.arguments[0] || t.stringLiteral("")
             }).expression
         );
     },
@@ -39,7 +39,7 @@ export default {
         // todo throw error if arguments exist
         path.replaceWithJS(
             t.callExpression(
-                t.memberExpression(t.identifier('Math'), t.identifier('abs')),
+                t.memberExpression(t.identifier("Math"), t.identifier("abs")),
                 [path.node.target]
             )
         );
@@ -47,7 +47,7 @@ export default {
     join(path) {
         path.replaceWithJS(
             t.callExpression(
-                t.memberExpression(path.node.target, t.identifier('join')),
+                t.memberExpression(path.node.target, t.identifier("join")),
                 path.node.arguments
             )
         );
@@ -57,8 +57,8 @@ export default {
         path.replaceWithJS(
             t.callExpression(
                 t.memberExpression(
-                    t.identifier('JSON'),
-                    t.identifier('stringify')
+                    t.identifier("JSON"),
+                    t.identifier("stringify")
                 ),
                 [path.node.target]
             )
@@ -66,7 +66,7 @@ export default {
     },
     length(path) {
         path.replaceWithJS(
-            t.memberExpression(path.node.target, t.identifier('length'))
+            t.memberExpression(path.node.target, t.identifier("length"))
         );
     },
     lower(path) {
@@ -74,7 +74,7 @@ export default {
             t.callExpression(
                 t.memberExpression(
                     path.node.target,
-                    t.identifier('toLowerCase')
+                    t.identifier("toLowerCase")
                 ),
                 []
             )
@@ -85,7 +85,7 @@ export default {
             t.callExpression(
                 t.memberExpression(
                     path.node.target,
-                    t.identifier('toUpperCase')
+                    t.identifier("toUpperCase")
                 ),
                 []
             )
@@ -94,7 +94,7 @@ export default {
     slice(path) {
         path.replaceWithJS(
             t.callExpression(
-                t.memberExpression(path.node.target, t.identifier('slice')),
+                t.memberExpression(path.node.target, t.identifier("slice")),
                 path.node.arguments
             )
         );
@@ -102,7 +102,7 @@ export default {
     sort(path) {
         path.replaceWithJS(
             t.callExpression(
-                t.memberExpression(path.node.target, t.identifier('sort')),
+                t.memberExpression(path.node.target, t.identifier("sort")),
                 path.node.arguments
             )
         );
@@ -110,7 +110,7 @@ export default {
     split(path) {
         path.replaceWithJS(
             t.callExpression(
-                t.memberExpression(path.node.target, t.identifier('split')),
+                t.memberExpression(path.node.target, t.identifier("split")),
                 path.node.arguments
             )
         );
@@ -123,7 +123,7 @@ export default {
         path.replaceWithJS(
             t.callExpression(
                 t.identifier(
-                    path.state.addImportFrom('melody-runtime', 'strtotime')
+                    path.state.addImportFrom("melody-runtime", "strtotime")
                 ),
                 [path.node.arguments[0], path.node.target]
             )
@@ -136,11 +136,11 @@ export default {
         path.replaceWithJS(
             t.callExpression(
                 t.callExpression(
-                    t.identifier(path.state.addDefaultImportFrom('moment')),
+                    t.identifier(path.state.addDefaultImportFrom("moment")),
                     [path.node.target]
                 ),
                 [path.node.arguments[0]]
             )
         );
-    },
+    }
 };

--- a/src/melody/melody-extension-core/visitors/for.js
+++ b/src/melody/melody-extension-core/visitors/for.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { traverse } from 'melody-traverse';
-import * as t from 'babel-types';
-import babelTemplate from 'babel-template';
+import { traverse } from "../../melody-traverse/index.js";
+import * as t from "babel-types";
+import babelTemplate from "babel-template";
 
 // @param template
 // @returns function
@@ -103,7 +103,7 @@ function parseExpr(exprStmt) {
     return {
         exprStmt: exprStmt,
         initDecl: exprStmt.body[0].declarations,
-        forStmt: exprStmt.body[1],
+        forStmt: exprStmt.body[1]
     };
 }
 
@@ -111,62 +111,62 @@ export default {
     analyse: {
         ForStatement: {
             enter(path) {
-                const forStmt = path.node,
-                    scope = path.scope;
+                const forStmt = path.node;
+                const scope = path.scope;
                 if (forStmt.keyTarget) {
                     scope.registerBinding(
                         forStmt.keyTarget.name,
-                        path.get('keyTarget'),
-                        'var'
+                        path.get("keyTarget"),
+                        "var"
                     );
                 }
                 if (forStmt.valueTarget) {
                     scope.registerBinding(
                         forStmt.valueTarget.name,
-                        path.get('valueTarget'),
-                        'var'
+                        path.get("valueTarget"),
+                        "var"
                     );
                 }
-                scope.registerBinding('loop', path, 'var');
+                scope.registerBinding("loop", path, "var");
             },
             exit(path) {
-                const sequenceName = path.scope.generateUid('sequence'),
-                    lenName = path.scope.generateUid('length');
-                path.scope.registerBinding(sequenceName, path, 'var');
-                path.scope.registerBinding(lenName, path, 'var');
+                const sequenceName = path.scope.generateUid("sequence");
+                const lenName = path.scope.generateUid("length");
+                path.scope.registerBinding(sequenceName, path, "var");
+                path.scope.registerBinding(lenName, path, "var");
                 let iName;
                 if (path.node.keyTarget) {
                     iName = path.node.keyTarget.name;
                 } else {
-                    iName = path.scope.generateUid('index0');
-                    path.scope.registerBinding(iName, path, 'var');
+                    iName = path.scope.generateUid("index0");
+                    path.scope.registerBinding(iName, path, "var");
                 }
-                path.setData('forStatement.variableLookup', {
+                path.setData("forStatement.variableLookup", {
                     sequenceName,
                     lenName,
-                    iName,
+                    iName
                 });
 
                 if (path.scope.escapesContext) {
-                    const contextName = path.scope.generateUid('context');
-                    path.scope.registerBinding(contextName, path, 'const');
+                    const contextName = path.scope.generateUid("context");
+                    path.scope.registerBinding(contextName, path, "const");
                     path.scope.contextName = contextName;
-                    path.scope.getBinding('loop').kind = 'context';
+                    path.scope.getBinding("loop").kind = "context";
                     if (path.node.valueTarget) {
                         path.scope.getBinding(path.node.valueTarget.name).kind =
-                            'context';
+                            "context";
                     }
-                } else if (path.scope.getBinding('loop').references) {
-                    const indexName = path.scope.generateUid('index');
-                    path.scope.registerBinding(indexName, path, 'var');
-                    const revindexName = path.scope.generateUid('revindex');
-                    path.scope.registerBinding(revindexName, path, 'var');
-                    const revindex0Name = path.scope.generateUid('revindex0');
-                    path.scope.registerBinding(revindex0Name, path, 'var');
-                    const firstName = path.scope.generateUid('first');
-                    path.scope.registerBinding(firstName, path, 'var');
-                    const lastName = path.scope.generateUid('last');
-                    path.scope.registerBinding(lastName, path, 'var');
+                } else if (path.scope.getBinding("loop").references) {
+                    const indexName = path.scope.generateUid("index");
+                    path.scope.registerBinding(indexName, path, "var");
+                    const revindexName = path.scope.generateUid("revindex");
+                    path.scope.registerBinding(revindexName, path, "var");
+                    const revindex0Name = path.scope.generateUid("revindex0");
+                    path.scope.registerBinding(revindex0Name, path, "var");
+                    const firstName = path.scope.generateUid("first");
+                    path.scope.registerBinding(firstName, path, "var");
+                    const lastName = path.scope.generateUid("last");
+                    path.scope.registerBinding(lastName, path, "var");
 
                     const lookupTable = {
                         index: indexName,
@@ -175,68 +175,68 @@ export default {
                         revindex: revindexName,
                         revindex0: revindex0Name,
                         first: firstName,
-                        last: lastName,
+                        last: lastName
                     };
-                    path.setData('forStatement.loopLookup', lookupTable);
+                    path.setData("forStatement.loopLookup", lookupTable);
 
-                    const loopBinding = path.scope.getBinding('loop');
+                    const loopBinding = path.scope.getBinding("loop");
                     for (const loopPath of loopBinding.referencePaths) {
                         const memExpr = loopPath.parentPath;
 
-                        if (memExpr.is('MemberExpression')) {
+                        if (memExpr.is("MemberExpression")) {
                             const typeName = memExpr.node.property.name;
-                            if (typeName === 'index0') {
+                            if (typeName === "index0") {
                                 memExpr.replaceWithJS({
-                                    type: 'BinaryExpression',
-                                    operator: '-',
+                                    type: "BinaryExpression",
+                                    operator: "-",
                                     left: {
-                                        type: 'Identifier',
-                                        name: indexName,
+                                        type: "Identifier",
+                                        name: indexName
                                     },
-                                    right: { type: 'NumericLiteral', value: 1 },
+                                    right: { type: "NumericLiteral", value: 1 },
                                     extra: {
-                                        parenthesized: true,
-                                    },
+                                        parenthesized: true
+                                    }
                                 });
                             } else {
                                 memExpr.replaceWithJS({
-                                    type: 'Identifier',
-                                    name: lookupTable[typeName],
+                                    type: "Identifier",
+                                    name: lookupTable[typeName]
                                 });
                             }
                         }
                     }
                 }
-            },
-        },
+            }
+        }
     },
     convert: {
         ForStatement: {
             enter(path) {
                 if (path.scope.escapesContext) {
-                    var parentContextName = path.scope.parent.contextName;
+                    const parentContextName = path.scope.parent.contextName;
                     if (path.node.otherwise) {
-                        const alternate = path.get('otherwise');
-                        if (alternate.is('Scope')) {
+                        const alternate = path.get("otherwise");
+                        if (alternate.is("Scope")) {
                             alternate.scope.contextName = parentContextName;
                         }
                     }
 
-                    const sequence = path.get('sequence');
+                    const sequence = path.get("sequence");
 
-                    if (sequence.is('Identifier')) {
+                    if (sequence.is("Identifier")) {
                         sequence.setData(
-                            'Identifier.contextName',
+                            "Identifier.contextName",
                             parentContextName
                         );
                     } else {
                         traverse(path.node.sequence, {
                             Identifier(id) {
                                 id.setData(
-                                    'Identifier.contextName',
+                                    "Identifier.contextName",
                                     parentContextName
                                 );
-                            },
+                            }
                         });
                     }
                 }
@@ -244,7 +244,7 @@ export default {
             exit(path) {
                 const node = path.node;
                 const { sequenceName, lenName, iName } = path.getData(
-                    'forStatement.variableLookup'
+                    "forStatement.variableLookup"
                 );
                 let expr;
                 if (path.scope.escapesContext) {
@@ -254,69 +254,69 @@ export default {
                         SUB_CONTEXT: t.identifier(contextName),
                         CREATE_SUB_CONTEXT: t.identifier(
                             this.addImportFrom(
-                                'melody-runtime',
-                                'createSubContext'
+                                "melody-runtime",
+                                "createSubContext"
                             )
                         ),
                         KEY_TARGET: t.identifier(iName),
-                        SOURCE: path.get('sequence').node,
+                        SOURCE: path.get("sequence").node,
                         SEQUENCE: t.identifier(sequenceName),
                         LENGTH: t.identifier(lenName),
-                        VALUE_TARGET: node.valueTarget,
+                        VALUE_TARGET: node.valueTarget
                     });
                     if (node.keyTarget) {
                         expr.forStmt.body.body.push({
-                            type: 'ExpressionStatement',
+                            type: "ExpressionStatement",
                             expression: {
-                                type: 'AssignmentExpression',
-                                operator: '=',
+                                type: "AssignmentExpression",
+                                operator: "=",
                                 left: {
-                                    type: 'MemberExpression',
+                                    type: "MemberExpression",
                                     object: {
-                                        type: 'Identifier',
-                                        name: contextName,
+                                        type: "Identifier",
+                                        name: contextName
                                     },
                                     property: {
-                                        type: 'Identifier',
-                                        name: node.keyTarget.name,
+                                        type: "Identifier",
+                                        name: node.keyTarget.name
                                     },
-                                    computed: false,
+                                    computed: false
                                 },
                                 right: {
-                                    type: 'Identifier',
-                                    name: iName,
-                                },
-                            },
+                                    type: "Identifier",
+                                    name: iName
+                                }
+                            }
                         });
                         expr.initDecl[
                             expr.initDecl.length - 1
                         ].init.arguments[1].properties.push({
-                            type: 'ObjectProperty',
+                            type: "ObjectProperty",
                             method: false,
                             shorthand: false,
                             computed: false,
                             key: {
-                                type: 'Identifier',
-                                name: node.keyTarget.name,
+                                type: "Identifier",
+                                name: node.keyTarget.name
                             },
                             value: {
-                                type: 'Identifier',
-                                name: iName,
-                            },
+                                type: "Identifier",
+                                name: iName
+                            }
                         });
                     }
-                } else if (path.scope.getBinding('loop').references) {
+                } else if (path.scope.getBinding("loop").references) {
                     const {
                         index: indexName,
                         revindex: revindexName,
                         revindex0: revindex0Name,
                         first: firstName,
-                        last: lastName,
-                    } = path.getData('forStatement.loopLookup');
+                        last: lastName
+                    } = path.getData("forStatement.loopLookup");
 
                     expr = localFor({
                         KEY_TARGET: t.identifier(iName),
-                        SOURCE: path.get('sequence').node,
+                        SOURCE: path.get("sequence").node,
                         SEQUENCE: t.identifier(sequenceName),
                         LENGTH: t.identifier(lenName),
                         VALUE_TARGET: node.valueTarget,
@@ -324,32 +324,32 @@ export default {
                         REVERSE_INDEX: t.identifier(revindex0Name),
                         REVERSE_INDEX_BY_1: t.identifier(revindexName),
                         FIRST: t.identifier(firstName),
-                        LAST: t.identifier(lastName),
+                        LAST: t.identifier(lastName)
                     });
                 } else {
                     expr = basicFor({
                         SEQUENCE: t.identifier(sequenceName),
-                        SOURCE: path.get('sequence').node,
+                        SOURCE: path.get("sequence").node,
                         KEY_TARGET: t.identifier(iName),
                         LENGTH: t.identifier(lenName),
-                        VALUE_TARGET: node.valueTarget,
+                        VALUE_TARGET: node.valueTarget
                     });
                 }
 
-                expr.forStmt.body.body.unshift(...path.get('body').node.body);
+                expr.forStmt.body.body.unshift(...path.get("body").node.body);
 
                 let uniteratedName;
                 if (node.otherwise) {
-                    uniteratedName = path.scope.generateUid('uniterated');
+                    uniteratedName = path.scope.generateUid("uniterated");
                     path.scope.parent.registerBinding(
                         uniteratedName,
                         path,
-                        'var'
+                        "var"
                     );
                     expr.forStmt.body.body.push(
                         t.expressionStatement(
                             t.assignmentExpression(
-                                '=',
+                                "=",
                                 t.identifier(uniteratedName),
                                 t.booleanLiteral(false)
                             )
@@ -360,22 +360,20 @@ export default {
                 if (node.condition) {
                     expr.forStmt.body = t.blockStatement([
                         {
-                            type: 'IfStatement',
+                            type: "IfStatement",
                             test: node.condition,
-                            consequent: t.blockStatement(
-                                expr.forStmt.body.body
-                            ),
-                        },
+                            consequent: t.blockStatement(expr.forStmt.body.body)
+                        }
                     ]);
                 }
 
                 if (uniteratedName) {
                     path.replaceWithMultipleJS(
-                        t.variableDeclaration('let', [
+                        t.variableDeclaration("let", [
                             t.variableDeclarator(
                                 t.identifier(uniteratedName),
                                 t.booleanLiteral(true)
-                            ),
+                            )
                         ]),
                         expr.exprStmt,
                         t.ifStatement(
@@ -386,7 +384,7 @@ export default {
                 } else {
                     path.replaceWithJS(expr.exprStmt);
                 }
-            },
-        },
-    },
+            }
+        }
+    }
 };

--- a/src/melody/melody-extension-core/visitors/functions.js
+++ b/src/melody/melody-extension-core/visitors/functions.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as t from 'babel-types';
+import * as t from "babel-types";
 
 function addOne(expr) {
-    return t.binaryExpression('+', expr, t.numericLiteral(1));
+    return t.binaryExpression("+", expr, t.numericLiteral(1));
 }
 
 export default {
@@ -33,36 +33,34 @@ export default {
             callArgs.push(args[0], addOne(args[1]));
         } else {
             path.state.error(
-                'Invalid range call',
+                "Invalid range call",
                 path.node.pos,
-                `The range function accepts 1 to 3 arguments but you have specified ${
-                    args.length
-                } arguments instead.`
+                `The range function accepts 1 to 3 arguments but you have specified ${args.length} arguments instead.`
             );
         }
 
         path.replaceWithJS(
             t.callExpression(
-                t.identifier(path.state.addImportFrom('lodash', 'range')),
+                t.identifier(path.state.addImportFrom("lodash", "range")),
                 callArgs
             )
         );
     },
     // range: 'lodash',
     dump(path) {
-        if (!path.parentPath.is('PrintExpressionStatement')) {
+        if (!path.parentPath.is("PrintExpressionStatement")) {
             path.state.error(
-                'dump must be used in a lone expression',
+                "dump must be used in a lone expression",
                 path.node.pos,
-                'The dump function does not have a return value. Thus it must be used as the only expression.'
+                "The dump function does not have a return value. Thus it must be used as the only expression."
             );
         }
         path.parentPath.replaceWithJS(
             t.expressionStatement(
                 t.callExpression(
                     t.memberExpression(
-                        t.identifier('console'),
-                        t.identifier('log')
+                        t.identifier("console"),
+                        t.identifier("log")
                     ),
                     path.node.arguments
                 )
@@ -70,15 +68,15 @@ export default {
         );
     },
     include(path) {
-        if (!path.parentPath.is('PrintExpressionStatement')) {
+        if (!path.parentPath.is("PrintExpressionStatement")) {
             path.state.error({
-                title: 'Include function does not return value',
+                title: "Include function does not return value",
                 pos: path.node.loc.start,
                 advice: `The include function currently does not return a value.
-                Thus you must use it like a regular include tag.`,
+                Thus you must use it like a regular include tag.`
             });
         }
-        const includeName = path.scope.generateUid('include');
+        const includeName = path.scope.generateUid("include");
         const importDecl = t.importDeclaration(
             [t.importDefaultSpecifier(t.identifier(includeName))],
             path.node.arguments[0]
@@ -92,11 +90,11 @@ export default {
             t.callExpression(
                 t.memberExpression(
                     t.identifier(includeName),
-                    t.identifier('render')
+                    t.identifier("render")
                 ),
                 argument ? [argument] : []
             )
         );
         path.replaceWithJS(includeCall);
-    },
+    }
 };

--- a/src/melody/melody-extension-core/visitors/tests.js
+++ b/src/melody/melody-extension-core/visitors/tests.js
@@ -13,115 +13,115 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as t from 'babel-types';
+import * as t from "babel-types";
 
 export default {
     convert: {
         TestEvenExpression: {
             exit(path) {
                 const expr = t.unaryExpression(
-                    '!',
+                    "!",
                     t.binaryExpression(
-                        '%',
-                        path.get('expression').node,
+                        "%",
+                        path.get("expression").node,
                         t.numericLiteral(2)
                     )
                 );
                 expr.extra = { parenthesizedArgument: true };
                 path.replaceWithJS(expr);
-            },
+            }
         },
         TestOddExpression: {
             exit(path) {
                 const expr = t.unaryExpression(
-                    '!',
+                    "!",
                     t.unaryExpression(
-                        '!',
+                        "!",
                         t.binaryExpression(
-                            '%',
-                            path.get('expression').node,
+                            "%",
+                            path.get("expression").node,
                             t.numericLiteral(2)
                         )
                     )
                 );
                 expr.extra = { parenthesizedArgument: true };
                 path.replaceWithJS(expr);
-            },
+            }
         },
         TestDefinedExpression: {
             exit(path) {
                 path.replaceWithJS(
                     t.binaryExpression(
-                        '!==',
+                        "!==",
                         t.unaryExpression(
-                            'typeof',
-                            path.get('expression').node
+                            "typeof",
+                            path.get("expression").node
                         ),
-                        t.stringLiteral('undefined')
+                        t.stringLiteral("undefined")
                     )
                 );
-            },
+            }
         },
         TestEmptyExpression: {
             exit(path) {
                 path.replaceWithJS(
                     t.callExpression(
                         t.identifier(
-                            this.addImportFrom('melody-runtime', 'isEmpty')
+                            this.addImportFrom("melody-runtime", "isEmpty")
                         ),
-                        [path.get('expression').node]
+                        [path.get("expression").node]
                     )
                 );
-            },
+            }
         },
         TestSameAsExpression: {
             exit(path) {
                 path.replaceWithJS(
                     t.binaryExpression(
-                        '===',
-                        path.get('expression').node,
-                        path.get('arguments')[0].node
+                        "===",
+                        path.get("expression").node,
+                        path.get("arguments")[0].node
                     )
                 );
-            },
+            }
         },
         TestNullExpression: {
             exit(path) {
                 path.replaceWithJS(
                     t.binaryExpression(
-                        '===',
-                        path.get('expression').node,
+                        "===",
+                        path.get("expression").node,
                         t.nullLiteral()
                     )
                 );
-            },
+            }
         },
         TestDivisibleByExpression: {
             exit(path) {
                 path.replaceWithJS(
                     t.unaryExpression(
-                        '!',
+                        "!",
                         t.binaryExpression(
-                            '%',
-                            path.get('expression').node,
+                            "%",
+                            path.get("expression").node,
                             path.node.arguments[0]
                         )
                     )
                 );
-            },
+            }
         },
         TestIterableExpression: {
             exit(path) {
                 path.replaceWithJS(
                     t.callExpression(
                         t.memberExpression(
-                            t.identifier('Array'),
-                            t.identifier('isArray')
+                            t.identifier("Array"),
+                            t.identifier("isArray")
                         ),
                         [path.node.expression]
                     )
                 );
-            },
-        },
-    },
+            }
+        }
+    }
 };

--- a/src/melody/melody-parser/Associativity.js
+++ b/src/melody/melody-parser/Associativity.js
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export var LEFT = Symbol();
-export var RIGHT = Symbol();
+export const LEFT = Symbol("LEFT");
+export const RIGHT = Symbol("RIGHT");

--- a/src/melody/melody-parser/CharStream.js
+++ b/src/melody/melody-parser/CharStream.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const EOF = Symbol();
+export const EOF = Symbol("EOF");
 
 export class CharStream {
     constructor(input) {
@@ -33,8 +33,8 @@ export class CharStream {
     }
 
     mark() {
-        let { line, column } = this.position,
-            index = this.index;
+        const { line, column } = this.position;
+        const index = this.index;
         return { line, column, index };
     }
 
@@ -45,12 +45,12 @@ export class CharStream {
     }
 
     la(offset) {
-        var index = this.index + offset;
+        const index = this.index + offset;
         return index < this.length ? this.input.charAt(index) : EOF;
     }
 
     lac(offset) {
-        var index = this.index + offset;
+        const index = this.index + offset;
         return index < this.length ? this.input.charCodeAt(index) : EOF;
     }
 
@@ -58,10 +58,10 @@ export class CharStream {
         if (this.index === this.length) {
             return EOF;
         }
-        var ch = this.input.charAt(this.index);
+        const ch = this.input.charAt(this.index);
         this.index++;
         this.position.column++;
-        if (ch === '\n') {
+        if (ch === "\n") {
             this.position.line += 1;
             this.position.column = 0;
         }

--- a/src/melody/melody-parser/GenericMultiTagParser.js
+++ b/src/melody/melody-parser/GenericMultiTagParser.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { setStartFromToken, setEndFromToken } from './util';
-import { GenericTagParser } from './GenericTagParser';
-import * as Types from './TokenTypes';
+import { setStartFromToken, setEndFromToken } from "./util.js";
+import { GenericTagParser } from "./GenericTagParser.js";
+import * as Types from "./TokenTypes.js";
 
 const tagMatchesOneOf = (tokenStream, tagNames) => {
     for (let i = 0; i < tagNames.length; i++) {
@@ -27,13 +27,13 @@ const tagMatchesOneOf = (tokenStream, tagNames) => {
 };
 
 export const createMultiTagParser = (tagName, subTags = []) => ({
-    name: 'genericTwigMultiTag',
+    name: "genericTwigMultiTag",
     parse(parser, token) {
-        const tokens = parser.tokens,
-            tagStartToken = tokens.la(-1);
+        const tokens = parser.tokens;
+        const tagStartToken = tokens.la(-1);
 
         if (subTags.length === 0) {
-            subTags.push('end' + tagName);
+            subTags.push("end" + tagName);
         }
 
         const twigTag = GenericTagParser.parse(parser, token);
@@ -62,5 +62,5 @@ export const createMultiTagParser = (tagName, subTags = []) => ({
         setEndFromToken(twigTag, tokens.la(0));
 
         return twigTag;
-    },
+    }
 });

--- a/src/melody/melody-parser/GenericTagParser.js
+++ b/src/melody/melody-parser/GenericTagParser.js
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { hasTagStartTokenTrimLeft, hasTagEndTokenTrimRight } from './util';
-import * as Types from './TokenTypes';
-import * as n from 'melody-types';
+import { hasTagStartTokenTrimLeft, hasTagEndTokenTrimRight } from "./util.js";
+import * as Types from "./TokenTypes.js";
+import * as n from "../melody-types/index.js";
 
 export const GenericTagParser = {
-    name: 'genericTwigTag',
+    name: "genericTwigTag",
     parse(parser) {
-        const tokens = parser.tokens,
-            tagStartToken = tokens.la(-2);
+        const tokens = parser.tokens;
+        const tagStartToken = tokens.la(-2);
         let currentToken;
 
         const twigTag = new n.GenericTwigTag(tokens.la(-1).text);
@@ -32,7 +32,7 @@ export const GenericTagParser = {
                 try {
                     twigTag.parts.push(parser.matchExpression());
                 } catch (e) {
-                    if (e.errorType === 'UNEXPECTED_TOKEN') {
+                    if (e.errorType === "UNEXPECTED_TOKEN") {
                         twigTag.parts.push(
                             new n.GenericToken(e.tokenType, e.tokenText)
                         );
@@ -49,5 +49,5 @@ export const GenericTagParser = {
         twigTag.trimRight = hasTagEndTokenTrimRight(currentToken);
 
         return twigTag;
-    },
+    }
 };

--- a/src/melody/melody-parser/Lexer.js
+++ b/src/melody/melody-parser/Lexer.js
@@ -13,41 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as TokenTypes from './TokenTypes';
-import { EOF } from './CharStream';
+import * as TokenTypes from "./TokenTypes.js";
+import { EOF } from "./CharStream.js";
 
 const State = {
-    TEXT: 'TEXT',
-    EXPRESSION: 'EXPRESSION',
-    TAG: 'TAG',
-    INTERPOLATION: 'INTERPOLATION',
-    STRING_SINGLE: 'STRING_SINGLE',
-    STRING_DOUBLE: 'STRING_DOUBLE',
-    ELEMENT: 'ELEMENT',
-    ATTRIBUTE_VALUE: 'ATTRIBUTE_VALUE',
-    DECLARATION: 'DECLARATION',
+    TEXT: "TEXT",
+    EXPRESSION: "EXPRESSION",
+    TAG: "TAG",
+    INTERPOLATION: "INTERPOLATION",
+    STRING_SINGLE: "STRING_SINGLE",
+    STRING_DOUBLE: "STRING_DOUBLE",
+    ELEMENT: "ELEMENT",
+    ATTRIBUTE_VALUE: "ATTRIBUTE_VALUE",
+    DECLARATION: "DECLARATION"
 };
 
-const STATE = Symbol(),
-    OPERATORS = Symbol(),
-    STRING_START = Symbol();
+const STATE = Symbol("STATE");
+const OPERATORS = Symbol("OPERATORS");
+const STRING_START = Symbol("STRING_START");
 
 const CHAR_TO_TOKEN = {
-    '[': TokenTypes.LBRACE,
-    ']': TokenTypes.RBRACE,
-    '(': TokenTypes.LPAREN,
-    ')': TokenTypes.RPAREN,
-    '{': TokenTypes.LBRACKET,
-    '}': TokenTypes.RBRACKET,
-    ':': TokenTypes.COLON,
-    '.': TokenTypes.DOT,
-    '|': TokenTypes.PIPE,
-    ',': TokenTypes.COMMA,
-    '?': TokenTypes.QUESTION_MARK,
-    '=': TokenTypes.ASSIGNMENT,
+    "[": TokenTypes.LBRACE,
+    "]": TokenTypes.RBRACE,
+    "(": TokenTypes.LPAREN,
+    ")": TokenTypes.RPAREN,
+    "{": TokenTypes.LBRACKET,
+    "}": TokenTypes.RBRACKET,
+    ":": TokenTypes.COLON,
+    ".": TokenTypes.DOT,
+    "|": TokenTypes.PIPE,
+    ",": TokenTypes.COMMA,
+    "?": TokenTypes.QUESTION_MARK,
+    "=": TokenTypes.ASSIGNMENT,
     //'<': TokenTypes.ELEMENT_START,
     //'>': TokenTypes.ELEMENT_END,
-    '/': TokenTypes.SLASH,
+    "/": TokenTypes.SLASH
 };
 
 export default class Lexer {
@@ -57,8 +57,7 @@ export default class Lexer {
         this[OPERATORS] = [];
         this[STRING_START] = null;
         this.options = {
-            preserveSourceLiterally:
-                preserveSourceLiterally === true ? true : false,
+            preserveSourceLiterally: preserveSourceLiterally === true
         };
     }
 
@@ -98,9 +97,9 @@ export default class Lexer {
     }
 
     createToken(type, pos) {
-        let input = this.input,
-            endPos = input.mark(),
-            end = endPos.index;
+        const input = this.input;
+        const endPos = input.mark();
+        const end = endPos.index;
         return {
             type,
             pos,
@@ -109,16 +108,16 @@ export default class Lexer {
             length: end - pos.index,
             source: input.input,
             text: input.input.substr(pos.index, end - pos.index),
-            toString: function() {
+            toString: function () {
                 return this.text;
-            },
+            }
         };
     }
 
     next() {
-        let input = this.input,
-            pos,
-            c;
+        const input = this.input;
+        let pos;
+        let c;
         while ((c = input.la(0)) !== EOF) {
             pos = input.mark();
             if (
@@ -134,20 +133,20 @@ export default class Lexer {
                 }
                 return this.createToken(TokenTypes.WHITESPACE, pos);
             }
-            if (c === '{' && input.la(1) === '#') {
+            if (c === "{" && input.la(1) === "#") {
                 input.next();
                 input.next();
-                if (input.la(0) === '-') {
+                if (input.la(0) === "-") {
                     input.next();
                 }
                 while ((c = input.la(0)) !== EOF) {
                     if (
-                        (c === '#' && input.la(1) === '}') ||
-                        (c === '-' &&
-                            input.la(1) === '#' &&
-                            input.la(2) === '}')
+                        (c === "#" && input.la(1) === "}") ||
+                        (c === "-" &&
+                            input.la(1) === "#" &&
+                            input.la(2) === "}")
                     ) {
-                        if (c === '-') {
+                        if (c === "-") {
                             input.next();
                         }
                         input.next();
@@ -159,19 +158,19 @@ export default class Lexer {
             }
             if (this.state === State.TEXT) {
                 let entityToken;
-                if (c === '<') {
+                if (c === "<") {
                     if (
-                        input.la(1) === '{' ||
+                        input.la(1) === "{" ||
                         isAlpha(input.lac(1)) ||
-                        input.la(1) === '/'
+                        input.la(1) === "/"
                     ) {
                         input.next();
                         this.pushState(State.ELEMENT);
                         return this.createToken(TokenTypes.ELEMENT_START, pos);
                     } else if (
-                        input.la(1) === '!' &&
-                        input.la(2) === '-' &&
-                        input.la(3) === '-'
+                        input.la(1) === "!" &&
+                        input.la(2) === "-" &&
+                        input.la(3) === "-"
                     ) {
                         // match HTML comment
                         input.next(); // <
@@ -179,12 +178,12 @@ export default class Lexer {
                         input.next(); // -
                         input.next(); // -
                         while ((c = input.la(0)) !== EOF) {
-                            if (c === '-' && input.la(1) === '-') {
+                            if (c === "-" && input.la(1) === "-") {
                                 input.next();
                                 input.next();
-                                if (!(c = input.next()) === '>') {
+                                if (!(c = input.next()) === ">") {
                                     this.error(
-                                        'Unexpected end for HTML comment',
+                                        "Unexpected end for HTML comment",
                                         input.mark(),
                                         `Expected comment to end with '>' but found '${c}' instead.`
                                     );
@@ -195,7 +194,7 @@ export default class Lexer {
                         }
                         return this.createToken(TokenTypes.HTML_COMMENT, pos);
                     } else if (
-                        input.la(1) === '!' &&
+                        input.la(1) === "!" &&
                         (isAlpha(input.lac(2)) || isWhitespace(input.la(2)))
                     ) {
                         input.next();
@@ -205,22 +204,20 @@ export default class Lexer {
                             TokenTypes.DECLARATION_START,
                             pos
                         );
-                    } else {
-                        return this.matchText(pos);
                     }
-                } else if (c === '{') {
-                    return this.matchExpressionToken(pos);
-                } else if (c === '&' && (entityToken = this.matchEntity(pos))) {
-                    return entityToken;
-                } else {
                     return this.matchText(pos);
+                } else if (c === "{") {
+                    return this.matchExpressionToken(pos);
+                } else if (c === "&" && (entityToken = this.matchEntity(pos))) {
+                    return entityToken;
                 }
+                return this.matchText(pos);
             } else if (this.state === State.EXPRESSION) {
                 if (
-                    (c === '}' && input.la(1) === '}') ||
-                    (c === '-' && input.la(1) === '}' && input.la(2) === '}')
+                    (c === "}" && input.la(1) === "}") ||
+                    (c === "-" && input.la(1) === "}" && input.la(2) === "}")
                 ) {
-                    if (c === '-') {
+                    if (c === "-") {
                         input.next();
                     }
                     input.next();
@@ -231,10 +228,10 @@ export default class Lexer {
                 return this.matchExpression(pos);
             } else if (this.state === State.TAG) {
                 if (
-                    (c === '%' && input.la(1) === '}') ||
-                    (c === '-' && input.la(1) === '%' && input.la(2) === '}')
+                    (c === "%" && input.la(1) === "}") ||
+                    (c === "-" && input.la(1) === "%" && input.la(2) === "}")
                 ) {
-                    if (c === '-') {
+                    if (c === "-") {
                         input.next();
                     }
                     input.next();
@@ -249,7 +246,7 @@ export default class Lexer {
             ) {
                 return this.matchString(pos, true);
             } else if (this.state === State.INTERPOLATION) {
-                if (c === '}') {
+                if (c === "}") {
                     input.next();
                     this.popState(); // pop interpolation
                     return this.createToken(TokenTypes.INTERPOLATION_END, pos);
@@ -257,12 +254,12 @@ export default class Lexer {
                 return this.matchExpression(pos);
             } else if (this.state === State.ELEMENT) {
                 switch (c) {
-                    case '/':
+                    case "/":
                         input.next();
                         return this.createToken(TokenTypes.SLASH, pos);
-                    case '{':
+                    case "{":
                         return this.matchExpressionToken(pos);
-                    case '>':
+                    case ">":
                         input.next();
                         this.popState();
                         return this.createToken(TokenTypes.ELEMENT_END, pos);
@@ -270,7 +267,7 @@ export default class Lexer {
                         input.next();
                         this.pushState(State.ATTRIBUTE_VALUE);
                         return this.createToken(TokenTypes.STRING_START, pos);
-                    case '=':
+                    case "=":
                         input.next();
                         return this.createToken(TokenTypes.ASSIGNMENT, pos);
                     default:
@@ -281,12 +278,11 @@ export default class Lexer {
                     input.next();
                     this.popState();
                     return this.createToken(TokenTypes.STRING_END, pos);
-                } else {
-                    return this.matchAttributeValue(pos);
                 }
+                return this.matchAttributeValue(pos);
             } else if (this.state === State.DECLARATION) {
                 switch (c) {
-                    case '>':
+                    case ">":
                         input.next();
                         this.popState();
                         return this.createToken(TokenTypes.ELEMENT_END, pos);
@@ -294,7 +290,7 @@ export default class Lexer {
                         input.next();
                         this.pushState(State.STRING_DOUBLE);
                         return this.createToken(TokenTypes.STRING_START, pos);
-                    case '{':
+                    case "{":
                         return this.matchExpressionToken(pos);
                     default:
                         return this.matchSymbol(pos);
@@ -309,26 +305,26 @@ export default class Lexer {
     matchExpressionToken(pos) {
         const input = this.input;
         switch (input.la(1)) {
-            case '{':
+            case "{":
                 input.next();
                 input.next();
                 this.pushState(State.EXPRESSION);
-                if (input.la(0) === '-') {
+                if (input.la(0) === "-") {
                     input.next();
                 }
                 return this.createToken(TokenTypes.EXPRESSION_START, pos);
-            case '%':
+            case "%":
                 input.next();
                 input.next();
                 this.pushState(State.TAG);
-                if (input.la(0) === '-') {
+                if (input.la(0) === "-") {
                     input.next();
                 }
                 return this.createToken(TokenTypes.TAG_START, pos);
-            case '#':
+            case "#":
                 input.next();
                 input.next();
-                if (input.la(0) === '-') {
+                if (input.la(0) === "-") {
                     input.next();
                 }
                 return this.matchComment(pos);
@@ -338,8 +334,8 @@ export default class Lexer {
     }
 
     matchExpression(pos) {
-        let input = this.input,
-            c = input.la(0);
+        const input = this.input;
+        const c = input.la(0);
         switch (c) {
             case "'":
                 this.pushState(State.STRING_SINGLE);
@@ -355,28 +351,26 @@ export default class Lexer {
                     return this.matchNumber(pos);
                 }
                 if (
-                    (c === 't' && input.match('true')) ||
-                    (c === 'T' && input.match('TRUE'))
+                    (c === "t" && input.match("true")) ||
+                    (c === "T" && input.match("TRUE"))
                 ) {
                     return this.createToken(TokenTypes.TRUE, pos);
                 }
                 if (
-                    (c === 'f' && input.match('false')) ||
-                    (c === 'F' && input.match('FALSE'))
+                    (c === "f" && input.match("false")) ||
+                    (c === "F" && input.match("FALSE"))
                 ) {
                     return this.createToken(TokenTypes.FALSE, pos);
                 }
                 if (
-                    (c === 'n' &&
-                        (input.match('null') || input.match('none'))) ||
-                    (c === 'N' && (input.match('NULL') || input.match('NONE')))
+                    (c === "n" &&
+                        (input.match("null") || input.match("none"))) ||
+                    (c === "N" && (input.match("NULL") || input.match("NONE")))
                 ) {
                     return this.createToken(TokenTypes.NULL, pos);
                 }
-                const {
-                    longestMatchingOperator,
-                    longestMatchEndPos,
-                } = this.findLongestMatchingOperator();
+                const { longestMatchingOperator, longestMatchEndPos } =
+                    this.findLongestMatchingOperator();
                 const cc = input.lac(0);
                 if (cc === 95 /* _ */ || isAlpha(cc) || isDigit(cc)) {
                     // okay... this could be either a symbol or an operator
@@ -392,26 +386,27 @@ export default class Lexer {
                 } else if (longestMatchingOperator) {
                     input.rewind(longestMatchEndPos);
                     return this.createToken(TokenTypes.OPERATOR, pos);
-                } else if (CHAR_TO_TOKEN.hasOwnProperty(c)) {
+                } else if (
+                    Object.prototype.hasOwnProperty.call(CHAR_TO_TOKEN, c)
+                ) {
                     input.next();
                     return this.createToken(CHAR_TO_TOKEN[c], pos);
-                } else if (c === '\xa0') {
+                } else if (c === "\xa0") {
                     return this.error(
-                        'Unsupported token: Non-breaking space',
+                        "Unsupported token: Non-breaking space",
                         pos
                     );
-                } else {
-                    return this.error(`Unknown token ${c}`, pos);
                 }
+                return this.error(`Unknown token ${c}`, pos);
             }
         }
     }
 
     findLongestMatchingOperator() {
-        const input = this.input,
-            start = input.mark();
-        let longestMatchingOperator = '',
-            longestMatchEndPos = null;
+        const input = this.input;
+        const start = input.mark();
+        let longestMatchingOperator = "";
+        let longestMatchEndPos = null;
         for (let i = 0, ops = this[OPERATORS], len = ops.length; i < len; i++) {
             const op = ops[i];
             if (op.length > longestMatchingOperator.length && input.match(op)) {
@@ -419,7 +414,7 @@ export default class Lexer {
 
                 // prevent mixing up operators with symbols (e.g. matching
                 // 'not in' in 'not invalid').
-                if (op.indexOf(' ') === -1 || !(isAlpha(cc) || isDigit(cc))) {
+                if (op.indexOf(" ") === -1 || !(isAlpha(cc) || isDigit(cc))) {
                     longestMatchingOperator = op;
                     longestMatchEndPos = input.mark();
                 }
@@ -431,7 +426,7 @@ export default class Lexer {
         return { longestMatchingOperator, longestMatchEndPos };
     }
 
-    error(message, pos, advice = '') {
+    error(message, pos, advice = "") {
         const errorToken = this.createToken(TokenTypes.ERROR, pos);
         errorToken.message = message;
         errorToken.advice = advice;
@@ -441,21 +436,21 @@ export default class Lexer {
     matchEntity(pos) {
         const input = this.input;
         input.next(); // &
-        if (input.la(0) === '#') {
+        if (input.la(0) === "#") {
             input.next(); // #
-            if (input.la(0) === 'x') {
+            if (input.la(0) === "x") {
                 // hexadecimal numeric character reference
                 input.next(); // x
                 let c = input.la(0);
                 while (
-                    ('a' <= c && c <= 'f') ||
-                    ('A' <= c && c <= 'F') ||
+                    ("a" <= c && c <= "f") ||
+                    ("A" <= c && c <= "F") ||
                     isDigit(input.lac(0))
                 ) {
                     input.next();
                     c = input.la(0);
                 }
-                if (input.la(0) === ';') {
+                if (input.la(0) === ";") {
                     input.next();
                 } else {
                     input.rewind(pos);
@@ -468,7 +463,7 @@ export default class Lexer {
                     input.next();
                 } while (isDigit(input.lac(0)));
                 // check for final ";"
-                if (input.la(0) === ';') {
+                if (input.la(0) === ";") {
                     input.next();
                 } else {
                     input.rewind(pos);
@@ -483,7 +478,7 @@ export default class Lexer {
             while (isAlpha(input.lac(0))) {
                 input.next();
             }
-            if (input.la(0) === ';') {
+            if (input.la(0) === ";") {
                 input.next();
             } else {
                 input.rewind(pos);
@@ -494,9 +489,9 @@ export default class Lexer {
     }
 
     matchSymbol(pos) {
-        let input = this.input,
-            inElement = this.state === State.ELEMENT,
-            c;
+        const input = this.input;
+        const inElement = this.state === State.ELEMENT;
+        let c;
         while (
             (c = input.lac(0)) &&
             (c === 95 ||
@@ -506,10 +501,10 @@ export default class Lexer {
         ) {
             input.next();
         }
-        var end = input.mark();
+        const end = input.mark();
         if (pos.index === end.index) {
             return this.error(
-                'Expected an Identifier',
+                "Expected an Identifier",
                 pos,
                 inElement
                     ? `Expected a valid attribute name, but instead found "${input.la(
@@ -524,11 +519,11 @@ export default class Lexer {
     }
 
     matchString(pos, allowInterpolation = true) {
-        const input = this.input,
-            start = this.state === State.STRING_SINGLE ? "'" : '"';
+        const input = this.input;
+        const start = this.state === State.STRING_SINGLE ? "'" : '"';
         let c;
         // string starts with an interpolation
-        if (allowInterpolation && input.la(0) === '#' && input.la(1) === '{') {
+        if (allowInterpolation && input.la(0) === "#" && input.la(1) === "{") {
             this.pushState(State.INTERPOLATION);
             input.next();
             input.next();
@@ -540,11 +535,11 @@ export default class Lexer {
             return this.createToken(TokenTypes.STRING_END, pos);
         }
         while ((c = input.la(0)) !== start && c !== EOF) {
-            if (c === '\\' && input.la(1) === start) {
+            if (c === "\\" && input.la(1) === start) {
                 // escape sequence for string start
                 input.next();
                 input.next();
-            } else if (allowInterpolation && c === '#' && input.la(1) === '{') {
+            } else if (allowInterpolation && c === "#" && input.la(1) === "{") {
                 // found interpolation start, string part matched
                 // next iteration will match the interpolation
                 break;
@@ -552,29 +547,29 @@ export default class Lexer {
                 input.next();
             }
         }
-        var result = this.createToken(TokenTypes.STRING, pos);
+        const result = this.createToken(TokenTypes.STRING, pos);
         // Replace double backslash before escaped quotes
         if (!this.options.preserveSourceLiterally) {
             result.text = result.text.replace(
-                new RegExp('(?:\\\\)(' + start + ')', 'g'),
-                '$1'
+                new RegExp("(?:\\\\)(" + start + ")", "g"),
+                "$1"
             );
         }
         return result;
     }
 
     matchAttributeValue(pos) {
-        let input = this.input,
-            start = this.state === State.STRING_SINGLE ? "'" : '"',
-            c;
-        if (input.la(0) === '{') {
+        const input = this.input;
+        const start = this.state === State.STRING_SINGLE ? "'" : '"';
+        let c;
+        if (input.la(0) === "{") {
             return this.matchExpressionToken(pos);
         }
         while ((c = input.la(0)) !== start && c !== EOF) {
-            if (c === '\\' && input.la(1) === start) {
+            if (c === "\\" && input.la(1) === start) {
                 input.next();
                 input.next();
-            } else if (c === '{') {
+            } else if (c === "{") {
                 // interpolation start
                 break;
             } else if (c === start) {
@@ -583,27 +578,27 @@ export default class Lexer {
                 input.next();
             }
         }
-        var result = this.createToken(TokenTypes.STRING, pos);
+        const result = this.createToken(TokenTypes.STRING, pos);
         // Replace double backslash before escaped quotes
         if (!this.options.preserveSourceLiterally) {
             result.text = result.text.replace(
-                new RegExp('(?:\\\\)(' + start + ')', 'g'),
-                '$1'
+                new RegExp("(?:\\\\)(" + start + ")", "g"),
+                "$1"
             );
         }
         return result;
     }
 
     matchNumber(pos) {
-        let input = this.input,
-            c;
+        const input = this.input;
+        let c;
         while ((c = input.lac(0)) !== EOF) {
             if (!isDigit(c)) {
                 break;
             }
             input.next();
         }
-        if (input.la(0) === '.' && isDigit(input.lac(1))) {
+        if (input.la(0) === "." && isDigit(input.lac(1))) {
             input.next();
             while ((c = input.lac(0)) !== EOF) {
                 if (!isDigit(c)) {
@@ -616,25 +611,25 @@ export default class Lexer {
     }
 
     matchText(pos) {
-        let input = this.input,
-            c;
+        const input = this.input;
+        let c;
         while ((c = input.la(0)) && c !== EOF) {
-            if (c === '{') {
+            if (c === "{") {
                 const c2 = input.la(1);
-                if (c2 === '{' || c2 === '#' || c2 === '%') {
+                if (c2 === "{" || c2 === "#" || c2 === "%") {
                     break;
                 }
-            } else if (c === '<') {
+            } else if (c === "<") {
                 const nextChar = input.la(1);
                 if (
-                    nextChar === '/' || // closing tag
-                    nextChar === '!' || // HTML comment
+                    nextChar === "/" || // closing tag
+                    nextChar === "!" || // HTML comment
                     isAlpha(input.lac(1)) // opening tag
                 ) {
                     break;
-                } else if (input.la(1) === '{') {
+                } else if (input.la(1) === "{") {
                     const c2 = input.la(1);
-                    if (c2 === '{' || c2 === '#' || c2 === '%') {
+                    if (c2 === "{" || c2 === "#" || c2 === "%") {
                         break;
                     }
                 }
@@ -645,10 +640,10 @@ export default class Lexer {
     }
 
     matchComment(pos) {
-        let input = this.input,
-            c;
+        const input = this.input;
+        let c;
         while ((c = input.next()) !== EOF) {
-            if (c === '#' && input.la(0) === '}') {
+            if (c === "#" && input.la(0) === "}") {
                 input.next(); // consume '}'
                 break;
             }
@@ -658,7 +653,7 @@ export default class Lexer {
 }
 
 function isWhitespace(c) {
-    return c === '\n' || c === ' ' || c === '\t';
+    return c === "\n" || c === " " || c === "\t";
 }
 
 function isAlpha(c) {
@@ -666,5 +661,5 @@ function isAlpha(c) {
 }
 
 function isDigit(c) {
-    return 48 <= c && c <= 57;
+    return c >= 48 && c <= 57;
 }

--- a/src/melody/melody-parser/TokenStream.js
+++ b/src/melody/melody-parser/TokenStream.js
@@ -25,14 +25,14 @@ import {
     EXPRESSION_START,
     EXPRESSION_END,
     TEXT,
-    STRING,
-} from './TokenTypes';
-import trimEnd from 'lodash/trimEnd';
-import trimStart from 'lodash/trimStart';
-import codeFrame from 'melody-code-frame';
+    STRING
+} from "./TokenTypes.js";
+import trimEnd from "lodash/trimEnd.js";
+import trimStart from "lodash/trimStart.js";
+import codeFrame from "../melody-code-frame/index.js";
 
-const TOKENS = Symbol(),
-    LENGTH = Symbol();
+const TOKENS = Symbol("TOKENS");
+const LENGTH = Symbol("LENGTH");
 
 export default class TokenStream {
     constructor(lexer, options) {
@@ -44,7 +44,7 @@ export default class TokenStream {
                 ignoreComments: true,
                 ignoreHtmlComments: true,
                 ignoreWhitespace: true,
-                applyWhitespaceTrimming: true,
+                applyWhitespaceTrimming: true
             },
             options
         );
@@ -66,7 +66,7 @@ export default class TokenStream {
     }
 
     la(offset) {
-        var index = this.index + offset;
+        const index = this.index + offset;
         return index < this[LENGTH] ? this[TOKENS][index] : EOF_TOKEN;
     }
 
@@ -101,13 +101,11 @@ export default class TokenStream {
             return this.next();
         }
         this.error(
-            'Invalid Token',
+            "Invalid Token",
             token.pos,
-            `Expected ${ERROR_TABLE[type] ||
-                type ||
-                text} but found ${ERROR_TABLE[token.type] ||
-                token.type ||
-                token.text} instead.`,
+            `Expected ${ERROR_TABLE[type] || type || text} but found ${
+                ERROR_TABLE[token.type] || token.type || token.text
+            } instead.`,
             token.length
         );
     }
@@ -122,11 +120,11 @@ export default class TokenStream {
             tokens: getAllTokens(this.input, {
                 ignoreWhitespace: false,
                 ignoreComments: false,
-                ignoreHtmlComments: false,
-            }),
+                ignoreHtmlComments: false
+            })
         });
         if (advice) {
-            errorMessage += '\n\n' + advice;
+            errorMessage += "\n\n" + advice;
         }
         const result = new Error(errorMessage);
         Object.assign(result, metadata);
@@ -135,10 +133,10 @@ export default class TokenStream {
 }
 
 function getAllTokens(lexer, options) {
-    let token,
-        tokens = [],
-        acceptWhitespaceControl = false,
-        trimNext = false;
+    let token;
+    const tokens = [];
+    let acceptWhitespaceControl = false;
+    let trimNext = false;
     while ((token = lexer.next()) !== EOF_TOKEN) {
         const shouldTrimNext = trimNext;
         trimNext = false;
@@ -146,7 +144,7 @@ function getAllTokens(lexer, options) {
             switch (token.type) {
                 case EXPRESSION_START:
                 case TAG_START:
-                    if (token.text[token.text.length - 1] === '-') {
+                    if (token.text[token.text.length - 1] === "-") {
                         tokens[tokens.length - 1].text = trimEnd(
                             tokens[tokens.length - 1].text
                         );
@@ -154,7 +152,7 @@ function getAllTokens(lexer, options) {
                     break;
                 case EXPRESSION_END:
                 case TAG_END:
-                    if (token.text[0] === '-') {
+                    if (token.text[0] === "-") {
                         trimNext = true;
                     }
                     break;

--- a/src/melody/melody-parser/TokenTypes.js
+++ b/src/melody/melody-parser/TokenTypes.js
@@ -13,55 +13,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const EXPRESSION_START = 'expressionStart';
-export const EXPRESSION_END = 'expressionEnd';
-export const TAG_START = 'tagStart';
-export const TAG_END = 'tagEnd';
-export const INTERPOLATION_START = 'interpolationStart';
-export const INTERPOLATION_END = 'interpolationEnd';
-export const STRING_START = 'stringStart';
-export const STRING_END = 'stringEnd';
-export const DECLARATION_START = 'declarationStart';
-export const COMMENT = 'comment';
-export const WHITESPACE = 'whitespace';
-export const HTML_COMMENT = 'htmlComment';
-export const TEXT = 'text';
-export const ENTITY = 'entity';
-export const SYMBOL = 'symbol';
-export const STRING = 'string';
-export const OPERATOR = 'operator';
-export const TRUE = 'true';
-export const FALSE = 'false';
-export const NULL = 'null';
-export const LBRACE = '[';
-export const RBRACE = ']';
-export const LPAREN = '(';
-export const RPAREN = ')';
-export const LBRACKET = '{';
-export const RBRACKET = '}';
-export const COLON = ':';
-export const COMMA = ',';
-export const DOT = '.';
-export const PIPE = '|';
-export const QUESTION_MARK = '?';
-export const ASSIGNMENT = '=';
-export const ELEMENT_START = '<';
-export const SLASH = '/';
-export const ELEMENT_END = '>';
-export const NUMBER = 'number';
-export const EOF = 'EOF';
-export const ERROR = 'ERROR';
+export const EXPRESSION_START = "expressionStart";
+export const EXPRESSION_END = "expressionEnd";
+export const TAG_START = "tagStart";
+export const TAG_END = "tagEnd";
+export const INTERPOLATION_START = "interpolationStart";
+export const INTERPOLATION_END = "interpolationEnd";
+export const STRING_START = "stringStart";
+export const STRING_END = "stringEnd";
+export const DECLARATION_START = "declarationStart";
+export const COMMENT = "comment";
+export const WHITESPACE = "whitespace";
+export const HTML_COMMENT = "htmlComment";
+export const TEXT = "text";
+export const ENTITY = "entity";
+export const SYMBOL = "symbol";
+export const STRING = "string";
+export const OPERATOR = "operator";
+export const TRUE = "true";
+export const FALSE = "false";
+export const NULL = "null";
+export const LBRACE = "[";
+export const RBRACE = "]";
+export const LPAREN = "(";
+export const RPAREN = ")";
+export const LBRACKET = "{";
+export const RBRACKET = "}";
+export const COLON = ":";
+export const COMMA = ",";
+export const DOT = ".";
+export const PIPE = "|";
+export const QUESTION_MARK = "?";
+export const ASSIGNMENT = "=";
+export const ELEMENT_START = "<";
+export const SLASH = "/";
+export const ELEMENT_END = ">";
+export const NUMBER = "number";
+export const EOF = "EOF";
+export const ERROR = "ERROR";
 export const EOF_TOKEN = {
     type: EOF,
     pos: {
         index: -1,
         line: -1,
-        pos: -1,
+        pos: -1
     },
     end: -1,
     length: 0,
     source: null,
-    text: '',
+    text: ""
 };
 
 export const ERROR_TABLE = {
@@ -70,5 +70,5 @@ export const ERROR_TABLE = {
     [TAG_START]: 'tag start "{%"',
     [TAG_END]: 'tag end "%}"',
     [INTERPOLATION_START]: 'interpolation start "#{"',
-    [INTERPOLATION_END]: 'interpolation end "}"',
+    [INTERPOLATION_END]: 'interpolation end "}"'
 };

--- a/src/melody/melody-parser/elementInfo.js
+++ b/src/melody/melody-parser/elementInfo.js
@@ -29,15 +29,15 @@ export const voidElements = {
     param: true,
     source: true,
     track: true,
-    wbr: true,
+    wbr: true
 };
 
 export const rawTextElements = {
     script: true,
-    style: true,
+    style: true
 };
 
 export const escapableRawTextElements = {
     textarea: true,
-    title: true,
+    title: true
 };

--- a/src/melody/melody-parser/index.js
+++ b/src/melody/melody-parser/index.js
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Parser from './Parser';
-import TokenStream from './TokenStream';
-import * as Types from './TokenTypes';
-import Lexer from './Lexer';
-import { EOF, CharStream } from './CharStream';
-import { LEFT, RIGHT } from './Associativity';
+import Parser from "./Parser.js";
+import TokenStream from "./TokenStream.js";
+import * as Types from "./TokenTypes.js";
+import Lexer from "./Lexer.js";
+import { EOF, CharStream } from "./CharStream.js";
+import { LEFT, RIGHT } from "./Associativity.js";
 import {
     setStartFromToken,
     setEndFromToken,
@@ -29,8 +29,8 @@ import {
     createNode,
     hasTagStartTokenTrimLeft,
     hasTagEndTokenTrimRight,
-    isMelodyExtension,
-} from './util';
+    isMelodyExtension
+} from "./util.js";
 
 function parse(code, options, ...extensions) {
     return createExtendedParser(code, options, ...extensions).parse();
@@ -90,5 +90,5 @@ export {
     createNode,
     hasTagStartTokenTrimLeft,
     hasTagEndTokenTrimRight,
-    Types,
+    Types
 };

--- a/src/melody/melody-parser/util.js
+++ b/src/melody/melody-parser/util.js
@@ -36,8 +36,8 @@ export function copyStart(
     node,
     {
         loc: {
-            start: { line, column, index },
-        },
+            start: { line, column, index }
+        }
     }
 ) {
     node.loc.start.line = line;
@@ -57,7 +57,7 @@ export function getNodeSource(node, entireSource) {
     if (entireSource && node.loc.start && node.loc.end) {
         return entireSource.substring(node.loc.start.index, node.loc.end.index);
     }
-    return '';
+    return "";
 }
 
 export function copyLoc(node, { loc: { start, end } }) {
@@ -79,19 +79,19 @@ export function startNode(Type, token, ...args) {
 }
 
 export function hasTagStartTokenTrimLeft(token) {
-    return token.text.endsWith('-');
+    return token.text.endsWith("-");
 }
 
 export function hasTagEndTokenTrimRight(token) {
-    return token.text.startsWith('-');
+    return token.text.startsWith("-");
 }
 
 export function isMelodyExtension(obj) {
     return (
         obj &&
         (Array.isArray(obj.binaryOperators) ||
-            typeof obj.filterMap === 'object' ||
-            typeof obj.functionMap === 'object' ||
+            typeof obj.filterMap === "object" ||
+            typeof obj.functionMap === "object" ||
             Array.isArray(obj.tags) ||
             Array.isArray(obj.tests) ||
             Array.isArray(obj.unaryOperators) ||

--- a/src/melody/melody-traverse/Binding.js
+++ b/src/melody/melody-traverse/Binding.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 export class Binding {
-    constructor(identifier, scope, path, kind = 'global') {
+    constructor(identifier, scope, path, kind = "global") {
         this.identifier = identifier;
         this.scope = scope;
         this.path = path;

--- a/src/melody/melody-traverse/Scope.js
+++ b/src/melody/melody-traverse/Scope.js
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Binding } from './Binding';
-import type Path from './Path';
-const CACHE_KEY = Symbol();
+import { Binding } from "./Binding.js";
+import Path from "./Path.js";
+const CACHE_KEY = Symbol("CACHE_KEY");
 let uid = 0;
 
 export default class Scope {
-    constructor(path: Path, parentScope?: Scope) {
+    /**
+     * @param {Path} path
+     * @param {Scope} [parentScope]
+     */
+    constructor(path, parentScope) {
         this.uid = uid++;
         this.parent = parentScope;
 
@@ -46,12 +50,16 @@ export default class Scope {
             return this._contextName;
         }
         if (this.parent) {
-            return this.parent.contextName || '_context';
+            return this.parent.contextName || "_context";
         }
-        return '_context';
+        return "_context";
     }
 
-    static get(path: Path, parentScope?: Scope) {
+    /**
+     * @param {Path} path
+     * @param Scope} parentScope
+     */
+    static get(path, parentScope) {
         if (parentScope && parentScope.block == path.node) {
             return parentScope;
         }
@@ -74,7 +82,10 @@ export default class Scope {
         return !!Object.keys(this.bindings).length;
     }
 
-    getBinding(name: string) {
+    /**
+     * @param {string} name
+     */
+    getBinding(name) {
         let scope = this;
 
         do {
@@ -82,21 +93,30 @@ export default class Scope {
             if (binding) {
                 return binding;
             }
-            if (scope.path.is('RootScope')) {
+            if (scope.path.is("RootScope")) {
                 return;
             }
         } while ((scope = scope.parent));
     }
 
-    getOwnBinding(name: string) {
+    /**
+     * @param {string} name
+     */
+    getOwnBinding(name) {
         return this.bindings[name];
     }
 
-    hasOwnBinding(name: string) {
+    /**
+     * @param {string} name
+     */
+    hasOwnBinding(name) {
         return !!this.getOwnBinding(name);
     }
 
-    hasBinding(name: string) {
+    /**
+     * @param {string} name
+     */
+    hasBinding(name) {
         return !name
             ? false
             : !!(this.hasOwnBinding(name) || this.parentHasBinding(name));
@@ -110,14 +130,19 @@ export default class Scope {
         return scope;
     }
 
-    registerBinding(name: string, path: Path = null, kind: string = 'context') {
+    /**
+     * @param {string} name
+     * @param {Path} path
+     * @param {string} kind
+     */
+    registerBinding(name, path = null, kind = "context") {
         let scope = this;
-        if (kind === 'global' && path === null) {
+        if (kind === "global" && path === null) {
             scope = this.getRootScope();
-        } else if (kind === 'const') {
+        } else if (kind === "const") {
             while (scope.parent) {
                 scope = scope.parent;
-                if (scope.path.is('RootScope')) {
+                if (scope.path.is("RootScope")) {
                     break;
                 }
             }
@@ -132,7 +157,11 @@ export default class Scope {
         return (scope.bindings[name] = new Binding(name, this, path, kind));
     }
 
-    reference(name: string, path: Path) {
+    /**
+     * @param {string} name
+     * @param {Path} path
+     */
+    reference(name, path) {
         let binding = this.getBinding(name);
         if (!binding) {
             binding = this.registerBinding(name);
@@ -140,15 +169,21 @@ export default class Scope {
         binding.reference(path);
     }
 
-    parentHasBinding(name: string) {
+    /**
+     * @param {string} name
+     */
+    parentHasBinding(name) {
         return this.parent && this.parent.hasBinding(name);
     }
 
-    generateUid(nameHint: string = 'temp') {
+    /**
+     * @param {string} nameHint
+     */
+    generateUid(nameHint = "temp") {
         const name = toIdentifier(nameHint);
 
-        let uid,
-            i = 0;
+        let uid;
+        let i = 0;
         do {
             uid = generateUid(name, i);
             i++;
@@ -163,15 +198,15 @@ function getCache(node) {
 }
 
 function toIdentifier(nameHint) {
-    let name = nameHint + '';
-    name = name.replace(/[^a-zA-Z0-9$_]/g, '');
+    let name = nameHint + "";
+    name = name.replace(/[^a-zA-Z0-9$_]/g, "");
 
-    name = name.replace(/^[-0-9]+/, '');
-    name = name.replace(/[-\s]+(.)?/, function(match, c) {
-        return c ? c.toUpperCase() : '';
+    name = name.replace(/^[-0-9]+/, "");
+    name = name.replace(/[-\s]+(.)?/, (match, c) => {
+        return c ? c.toUpperCase() : "";
     });
 
-    name = name.replace(/^_+/, '').replace(/[0-9]+$/, '');
+    name = name.replace(/^_+/, "").replace(/[0-9]+$/, "");
     return name;
 }
 

--- a/src/melody/melody-traverse/TraversalContext.js
+++ b/src/melody/melody-traverse/TraversalContext.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Path from './Path';
+import Path from "./Path.js";
 
 export default class TraversalContext {
     constructor(scope, visitor, state, parentPath) {
@@ -26,30 +26,38 @@ export default class TraversalContext {
         this.priorityQueue = null;
     }
 
-    create(parent, container, key, listKey): Path {
+    /**
+     * @returns {Path}
+     */
+    create(parent, container, key, listKey) {
         return Path.get({
             parentPath: this.parentPath,
             parent,
             container,
             key,
-            listKey,
+            listKey
         });
     }
 
-    shouldVisit(node): boolean {
+    /**
+     * @returns {boolean}
+     */
+    shouldVisit(node) {
         const visitor = this.visitor;
 
         if (visitor[node.type]) {
             return true;
         }
 
-        const keys: Array<String> = node.visitorKeys;
+        /** @type {Array<String>} */
+        const keys = node.visitorKeys;
         // this node doesn't have any children
         if (!keys || !keys.length) {
             return false;
         }
 
-        let i, len;
+        let i;
+        let len;
         for (i = 0, len = keys.length; i < len; i++) {
             // check if some of its visitor keys have a value,
             // if so, we need to visit it
@@ -62,24 +70,25 @@ export default class TraversalContext {
     }
 
     visit(node, key) {
-        var nodes = node[key];
+        const nodes = node[key];
         if (!nodes) {
             return false;
         }
 
         if (Array.isArray(nodes)) {
             return this.visitMultiple(nodes, node, key);
-        } else {
-            return this.visitSingle(node, key);
         }
+        return this.visitSingle(node, key);
     }
 
-    visitSingle(node, key): boolean {
+    /**
+     * @returns {boolean}
+     */
+    visitSingle(node, key) {
         if (this.shouldVisit(node[key])) {
             return this.visitQueue([this.create(node, node, key)]);
-        } else {
-            return false;
         }
+        return false;
     }
 
     visitMultiple(container, parent, listKey) {
@@ -99,12 +108,15 @@ export default class TraversalContext {
         return this.visitQueue(queue);
     }
 
-    visitQueue(queue: Array<Path>) {
+    /**
+     * @param {Array<Path>} queue
+     */
+    visitQueue(queue) {
         this.queue = queue;
         this.priorityQueue = [];
 
-        let visited = [],
-            stop = false;
+        const visited = [];
+        let stop = false;
 
         for (const path of queue) {
             path.resync();
@@ -139,7 +151,10 @@ export default class TraversalContext {
         return stop;
     }
 
-    maybeQueue(path, notPriority?: boolean) {
+    /**
+     * @param {boolean} [notPriority]
+     */
+    maybeQueue(path, notPriority) {
         if (this.queue) {
             if (notPriority) {
                 this.queue.push(path);

--- a/src/melody/melody-traverse/index.js
+++ b/src/melody/melody-traverse/index.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Path from './Path';
-import Scope from './Scope';
+import Path from "./Path.js";
+import Scope from "./Scope.js";
 export { Scope, Path };
-export * from './Scope';
-export { merge, explode } from './visitors';
-export { traverse, visit } from './traverse';
+export * from "./Scope.js";
+export { merge, explode } from "./visitors.js";
+export { traverse, visit } from "./traverse.js";

--- a/src/melody/melody-traverse/traverse.js
+++ b/src/melody/melody-traverse/traverse.js
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { explode } from './visitors';
-import TraversalContext from './TraversalContext';
+import { explode } from "./visitors.js";
+import TraversalContext from "./TraversalContext.js";
 
-export function traverse(
-    parentNode,
-    visitor: Object,
-    scope?: Object,
-    state?: Object = {},
-    parentPath?: Object
-) {
+/**
+ * @param {Object} visitor
+ * @param {Object} [scope]
+ * @param {Object} [state]
+ * @param {Object} [parentPath]
+ */
+export function traverse(parentNode, visitor, scope, state = {}, parentPath) {
     if (!parentNode) {
         return;
     }
@@ -32,7 +32,8 @@ export function traverse(
 }
 
 export function visit(node, visitor, scope, state, parentPath) {
-    const keys: Array<String> = node.visitorKeys;
+    /** @type {Array<String>} */
+    const keys = node.visitorKeys;
     if (!keys || !keys.length) {
         return;
     }

--- a/src/melody/melody-traverse/visitors.js
+++ b/src/melody/melody-traverse/visitors.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ALIAS_TO_TYPE } from 'melody-types';
+import { ALIAS_TO_TYPE } from "../melody-types/index.js";
 
-const EXPLODED = Symbol();
+const EXPLODED = Symbol("EXPLODED");
 
 export function explode(visitor) {
     if (visitor[EXPLODED]) {
@@ -26,7 +26,7 @@ export function explode(visitor) {
     for (const key of Object.getOwnPropertyNames(visitor)) {
         // make sure all members are objects with enter and exit methods
         let fns = visitor[key];
-        if (typeof fns === 'function') {
+        if (typeof fns === "function") {
             fns = visitor[key] = { enter: fns };
         }
 
@@ -71,7 +71,10 @@ export function explode(visitor) {
     }
 }
 
-export function merge(...visitors: Array) {
+/**
+ * @param {...Array} visitors
+ */
+export function merge(...visitors) {
     const rootVisitor = {};
 
     let i = 0;

--- a/src/melody/melody-types/index.js
+++ b/src/melody/melody-types/index.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as t from 'babel-types';
+import * as t from "babel-types";
 
 export const TYPE_MAP = Object.create(null);
 export const ALIAS_TO_TYPE = Object.create(null);
-export const PATH_CACHE_KEY = Symbol();
+export const PATH_CACHE_KEY = Symbol("PATH_CACHE_KEY");
 
 const IS_ALIAS_OF = Object.create(null);
 
@@ -27,7 +27,7 @@ export class Node {
         this.loc = {
             source: null,
             start: { line: 0, column: 0 },
-            end: { line: 0, column: 0 },
+            end: { line: 0, column: 0 }
         };
         this[PATH_CACHE_KEY] = [];
     }
@@ -35,7 +35,7 @@ export class Node {
     toJSON() {
         return Object.getOwnPropertyNames(this).reduce(
             (acc, name) => {
-                if (name === 'loc' || name === 'parent') {
+                if (name === "loc" || name === "parent") {
                     return acc;
                 }
                 const value = this[name];
@@ -47,17 +47,17 @@ export class Node {
                 return acc;
             },
             {
-                type: this.type,
+                type: this.type
             }
         );
     }
 
     static registerType(type) {
-        if (Node['is' + type]) {
+        if (Node["is" + type]) {
             return;
         }
 
-        Node['is' + type] = function(node) {
+        Node["is" + type] = function (node) {
             return is(node, type);
         };
 
@@ -68,10 +68,12 @@ export class Node {
         // };
     }
 }
-Node.registerType('Scope');
+Node.registerType("Scope");
 
 export function is(node, type) {
-    if (!node) return false;
+    if (!node) {
+        return false;
+    }
 
     return (
         node.type === type ||
@@ -80,11 +82,17 @@ export function is(node, type) {
     );
 }
 
-export function visitor(type, ...fields: String) {
+/**
+ * @param  {...string} fields
+ */
+export function visitor(type, ...fields) {
     type.prototype.visitorKeys = fields;
 }
 
-export function alias(type, ...aliases: String) {
+/**
+ * @param  {...string} aliases
+ */
+export function alias(type, ...aliases) {
     type.prototype.aliases = aliases;
     for (let i = 0, len = aliases.length; i < len; i++) {
         const alias = aliases[i];
@@ -100,7 +108,10 @@ export function alias(type, ...aliases: String) {
     }
 }
 
-export function type(Type, type: String) {
+/**
+ * @param  {...string} type
+ */
+export function type(Type, type) {
     Type.prototype.type = type;
     TYPE_MAP[type] = Type;
 
@@ -108,34 +119,43 @@ export function type(Type, type: String) {
 }
 
 export class Fragment extends Node {
-    constructor(expression: Node) {
+    /**
+     * @param  {Node} expression
+     */
+    constructor(expression) {
         super();
         this.value = expression;
     }
 }
-type(Fragment, 'Fragment');
-alias(Fragment, 'Statement');
-visitor(Fragment, 'value');
+type(Fragment, "Fragment");
+alias(Fragment, "Statement");
+visitor(Fragment, "value");
 
 export class PrintExpressionStatement extends Node {
-    constructor(expression: Node) {
+    /**
+     * @param  {Node} expression
+     */
+    constructor(expression) {
         super();
         this.value = expression;
     }
 }
-type(PrintExpressionStatement, 'PrintExpressionStatement');
-alias(PrintExpressionStatement, 'Statement', 'PrintStatement');
-visitor(PrintExpressionStatement, 'value');
+type(PrintExpressionStatement, "PrintExpressionStatement");
+alias(PrintExpressionStatement, "Statement", "PrintStatement");
+visitor(PrintExpressionStatement, "value");
 
 export class PrintTextStatement extends Node {
-    constructor(text: StringLiteral) {
+    /**
+     * @param {StringLiteral} text
+     */
+    constructor(text) {
         super();
         this.value = text;
     }
 }
-type(PrintTextStatement, 'PrintTextStatement');
-alias(PrintTextStatement, 'Statement', 'PrintStatement');
-visitor(PrintTextStatement, 'value');
+type(PrintTextStatement, "PrintTextStatement");
+alias(PrintTextStatement, "Statement", "PrintStatement");
+visitor(PrintTextStatement, "value");
 
 export class ConstantValue extends Node {
     constructor(value) {
@@ -147,32 +167,32 @@ export class ConstantValue extends Node {
         return `Const(${this.value})`;
     }
 }
-type(ConstantValue, 'ConstantValue');
-alias(ConstantValue, 'Expression', 'Literal', 'Immutable');
+type(ConstantValue, "ConstantValue");
+alias(ConstantValue, "Expression", "Literal", "Immutable");
 
 export class StringLiteral extends ConstantValue {}
-type(StringLiteral, 'StringLiteral');
-alias(StringLiteral, 'Expression', 'Literal', 'Immutable');
+type(StringLiteral, "StringLiteral");
+alias(StringLiteral, "Expression", "Literal", "Immutable");
 
 export class NumericLiteral extends ConstantValue {}
-type(NumericLiteral, 'NumericLiteral');
-alias(NumericLiteral, 'Expression', 'Literal', 'Immutable');
+type(NumericLiteral, "NumericLiteral");
+alias(NumericLiteral, "Expression", "Literal", "Immutable");
 
 export class BooleanLiteral extends ConstantValue {
     constructor(value) {
         super(value);
     }
 }
-type(BooleanLiteral, 'BooleanLiteral');
-alias(BooleanLiteral, 'Expression', 'Literal', 'Immutable');
+type(BooleanLiteral, "BooleanLiteral");
+alias(BooleanLiteral, "Expression", "Literal", "Immutable");
 
 export class NullLiteral extends ConstantValue {
     constructor() {
         super(null);
     }
 }
-type(NullLiteral, 'NullLiteral');
-alias(NullLiteral, 'Expression', 'Literal', 'Immutable');
+type(NullLiteral, "NullLiteral");
+alias(NullLiteral, "Expression", "Literal", "Immutable");
 
 export class Identifier extends Node {
     constructor(name) {
@@ -180,53 +200,71 @@ export class Identifier extends Node {
         this.name = name;
     }
 }
-type(Identifier, 'Identifier');
-alias(Identifier, 'Expression');
+type(Identifier, "Identifier");
+alias(Identifier, "Expression");
 
 export class UnaryExpression extends Node {
-    constructor(operator: String, argument: Node) {
+    /**
+     * @param {String} operator
+     * @param {Node} argument
+     */
+    constructor(operator, argument) {
         super();
         this.operator = operator;
         this.argument = argument;
     }
 }
-type(UnaryExpression, 'UnaryExpression');
-alias(UnaryExpression, 'Expression', 'UnaryLike');
-visitor(UnaryExpression, 'argument');
+type(UnaryExpression, "UnaryExpression");
+alias(UnaryExpression, "Expression", "UnaryLike");
+visitor(UnaryExpression, "argument");
 
 export class BinaryExpression extends Node {
-    constructor(operator: String, left: Node, right: Node) {
+    /**
+     * @param {String} operator
+     * @param {Node} left
+     * @param {Node} right
+     */
+    constructor(operator, left, right) {
         super();
         this.operator = operator;
         this.left = left;
         this.right = right;
     }
 }
-type(BinaryExpression, 'BinaryExpression');
-alias(BinaryExpression, 'Binary', 'Expression');
-visitor(BinaryExpression, 'left', 'right');
+type(BinaryExpression, "BinaryExpression");
+alias(BinaryExpression, "Binary", "Expression");
+visitor(BinaryExpression, "left", "right");
 
 export class BinaryConcatExpression extends BinaryExpression {
-    constructor(left: Node, right: Node) {
-        super('~', left, right);
+    /**
+     * @param {Node} left
+     * @param {Node} right
+     */
+    constructor(left, right) {
+        super("~", left, right);
         this.wasImplicitConcatenation = false;
     }
 }
-type(BinaryConcatExpression, 'BinaryConcatExpression');
-alias(BinaryConcatExpression, 'BinaryExpression', 'Binary', 'Expression');
-visitor(BinaryConcatExpression, 'left', 'right');
+type(BinaryConcatExpression, "BinaryConcatExpression");
+alias(BinaryConcatExpression, "BinaryExpression", "Binary", "Expression");
+visitor(BinaryConcatExpression, "left", "right");
 
 export class ConditionalExpression extends Node {
-    constructor(test: Node, consequent: Node, alternate: Node) {
+    /**
+     * @param {Node} test
+     * @param {Node} consequent
+     * @param {Node} alternate
+     */
+    constructor(test, consequent, alternate) {
         super();
         this.test = test;
         this.consequent = consequent;
         this.alternate = alternate;
     }
 }
-type(ConditionalExpression, 'ConditionalExpression');
-alias(ConditionalExpression, 'Expression', 'Conditional');
-visitor(ConditionalExpression, 'test', 'consequent', 'alternate');
+type(ConditionalExpression, "ConditionalExpression");
+alias(ConditionalExpression, "Expression", "Conditional");
+visitor(ConditionalExpression, "test", "consequent", "alternate");
 
 export class ArrayExpression extends Node {
     constructor(elements = []) {
@@ -234,107 +272,147 @@ export class ArrayExpression extends Node {
         this.elements = elements;
     }
 }
-type(ArrayExpression, 'ArrayExpression');
-alias(ArrayExpression, 'Expression');
-visitor(ArrayExpression, 'elements');
+type(ArrayExpression, "ArrayExpression");
+alias(ArrayExpression, "Expression");
+visitor(ArrayExpression, "elements");
 
 export class MemberExpression extends Node {
-    constructor(object: Node, property: Node, computed: boolean) {
+    /**
+     * @param {Node} object
+     * @param {Node} property
+     * @param {boolean} computed
+     */
+    constructor(object, property, computed) {
         super();
         this.object = object;
         this.property = property;
         this.computed = computed;
     }
 }
-type(MemberExpression, 'MemberExpression');
-alias(MemberExpression, 'Expression', 'LVal');
-visitor(MemberExpression, 'object', 'property');
+type(MemberExpression, "MemberExpression");
+alias(MemberExpression, "Expression", "LVal");
+visitor(MemberExpression, "object", "property");
 
 export class CallExpression extends Node {
-    constructor(callee: Node, args: Array<Node>) {
+    /**
+     * @param {Node} callee
+     * @param {Array<Node>} args
+     */
+    constructor(callee, args) {
         super();
         this.callee = callee;
         this.arguments = args;
     }
 }
-type(CallExpression, 'CallExpression');
-alias(CallExpression, 'Expression', 'FunctionInvocation');
-visitor(CallExpression, 'callee', 'arguments');
+type(CallExpression, "CallExpression");
+alias(CallExpression, "Expression", "FunctionInvocation");
+visitor(CallExpression, "callee", "arguments");
 
 export class NamedArgumentExpression extends Node {
-    constructor(name: Identifier, value: Node) {
+    /**
+     * @param {Identifier} name
+     * @param {Node} value
+     */
+    constructor(name, value) {
         super();
         this.name = name;
         this.value = value;
     }
 }
-type(NamedArgumentExpression, 'NamedArgumentExpression');
-alias(NamedArgumentExpression, 'Expression');
-visitor(NamedArgumentExpression, 'name', 'value');
+type(NamedArgumentExpression, "NamedArgumentExpression");
+alias(NamedArgumentExpression, "Expression");
+visitor(NamedArgumentExpression, "name", "value");
 
 export class ObjectExpression extends Node {
-    constructor(properties: Array<ObjectProperty> = []) {
+    /**
+     * @param {Array<ObjectProperty>} properties
+     */
+    constructor(properties = []) {
         super();
         this.properties = properties;
     }
 }
-type(ObjectExpression, 'ObjectExpression');
-alias(ObjectExpression, 'Expression');
-visitor(ObjectExpression, 'properties');
+type(ObjectExpression, "ObjectExpression");
+alias(ObjectExpression, "Expression");
+visitor(ObjectExpression, "properties");
 
 export class ObjectProperty extends Node {
-    constructor(key: Node, value: Node, computed: boolean) {
+    /**
+     * @param {Node} key
+     * @param {Node} value
+     * @param {boolean} computed
+     */
+    constructor(key, value, computed) {
         super();
         this.key = key;
         this.value = value;
         this.computed = computed;
     }
 }
-type(ObjectProperty, 'ObjectProperty');
-alias(ObjectProperty, 'Property', 'ObjectMember');
-visitor(ObjectProperty, 'key', 'value');
+type(ObjectProperty, "ObjectProperty");
+alias(ObjectProperty, "Property", "ObjectMember");
+visitor(ObjectProperty, "key", "value");
 
 export class SequenceExpression extends Node {
-    constructor(expressions: Array<Node> = []) {
+    /**
+     * @param {Array<Node>} expressions
+     */
+    constructor(expressions = []) {
         super();
         this.expressions = expressions;
     }
 
-    add(child: Node) {
+    /**
+     * @param {Node} child
+     */
+    add(child) {
         this.expressions.push(child);
         this.loc.end = child.loc.end;
     }
 }
-type(SequenceExpression, 'SequenceExpression');
-alias(SequenceExpression, 'Expression', 'Scope');
-visitor(SequenceExpression, 'expressions');
+type(SequenceExpression, "SequenceExpression");
+alias(SequenceExpression, "Expression", "Scope");
+visitor(SequenceExpression, "expressions");
 
 export class SliceExpression extends Node {
-    constructor(target: Node, start: Node, end: Node) {
+    /**
+     * @param {Node} target
+     * @param {Node} start
+     * @param {Node} end
+     */
+    constructor(target, start, end) {
         super();
         this.target = target;
         this.start = start;
         this.end = end;
     }
 }
-type(SliceExpression, 'SliceExpression');
-alias(SliceExpression, 'Expression');
-visitor(SliceExpression, 'source', 'start', 'end');
+type(SliceExpression, "SliceExpression");
+alias(SliceExpression, "Expression");
+visitor(SliceExpression, "source", "start", "end");
 
 export class FilterExpression extends Node {
-    constructor(target: Node, name: Identifier, args: Array<Node>) {
+    /**
+     * @param {Node} target
+     * @param {Identifier} name
+     * @param {Array<Node>} args
+     */
+    constructor(target, name, args) {
         super();
         this.target = target;
         this.name = name;
         this.arguments = args;
     }
 }
-type(FilterExpression, 'FilterExpression');
-alias(FilterExpression, 'Expression');
-visitor(FilterExpression, 'target', 'arguments');
+type(FilterExpression, "FilterExpression");
+alias(FilterExpression, "Expression");
+visitor(FilterExpression, "target", "arguments");
 
 export class Element extends Node {
-    constructor(name: String) {
+    /**
+     * @param {String} name
+     */
+    constructor(name) {
         super();
         this.name = name;
         this.attributes = [];
@@ -342,67 +420,87 @@ export class Element extends Node {
         this.selfClosing = false;
     }
 }
-type(Element, 'Element');
-alias(Element, 'Expression');
-visitor(Element, 'attributes', 'children');
+type(Element, "Element");
+alias(Element, "Expression");
+visitor(Element, "attributes", "children");
 
 export class Attribute extends Node {
-    constructor(name: Node, value: Node = null) {
+    /**
+     * @param {Node} name
+     * @param {Node} value
+     */
+    constructor(name, value = null) {
         super();
         this.name = name;
         this.value = value;
     }
 
     isImmutable() {
-        return is(this.name, 'Identifier') && is(this.value, 'Immutable');
+        return is(this.name, "Identifier") && is(this.value, "Immutable");
     }
 }
-type(Attribute, 'Attribute');
-visitor(Attribute, 'name', 'value');
+type(Attribute, "Attribute");
+visitor(Attribute, "name", "value");
 
 export class TwigComment extends Node {
-    constructor(text: StringLiteral) {
+    /**
+     * @param {StringLiteral} text
+     */
+    constructor(text) {
         super();
         this.value = text;
     }
 }
-type(TwigComment, 'TwigComment');
-visitor(TwigComment, 'value');
+type(TwigComment, "TwigComment");
+visitor(TwigComment, "value");
 
 export class HtmlComment extends Node {
-    constructor(text: StringLiteral) {
+    /**
+     * @param {StringLiteral} text
+     */
+    constructor(text) {
         super();
         this.value = text;
     }
 }
-type(HtmlComment, 'HtmlComment');
-visitor(HtmlComment, 'value');
+type(HtmlComment, "HtmlComment");
+visitor(HtmlComment, "value");
 
 export class Declaration extends Node {
-    constructor(declarationType: String) {
+    /**
+     * @param {String} declarationType
+     */
+    constructor(declarationType) {
         super();
         this.declarationType = declarationType;
         this.parts = [];
     }
 }
-type(Declaration, 'Declaration');
-visitor(Declaration, 'parts');
+type(Declaration, "Declaration");
+visitor(Declaration, "parts");
 
 export class GenericTwigTag extends Node {
-    constructor(tagName: String) {
+    /**
+     * @param {String} tagName
+     */
+    constructor(tagName) {
         super();
         this.tagName = tagName;
         this.parts = [];
         this.sections = [];
     }
 }
-type(GenericTwigTag, 'GenericTwigTag');
+type(GenericTwigTag, "GenericTwigTag");
 
 export class GenericToken extends Node {
-    constructor(tokenType: String, tokenText: String) {
+    /**
+     * @param {String} tokenType
+     * @param {String} tokenText
+     */
+    constructor(tokenType, tokenText) {
         super();
         this.tokenType = tokenType;
         this.tokenText = tokenText;
     }
 }
-type(GenericToken, 'GenericToken');
+type(GenericToken, "GenericToken");

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,5 +1,10 @@
-import { CharStream, Lexer, TokenStream, Parser } from "melody-parser";
-import { extension as coreExtension } from "melody-extension-core";
+import {
+    CharStream,
+    Lexer,
+    TokenStream,
+    Parser
+} from "./melody/melody-parser/index.js";
+import { extension as coreExtension } from "./melody/melody-extension-core/index.js";
 
 const ORIGINAL_SOURCE = Symbol("ORIGINAL_SOURCE");
 

--- a/src/print/Attribute.js
+++ b/src/print/Attribute.js
@@ -1,4 +1,4 @@
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import { EXPRESSION_NEEDED, STRING_NEEDS_QUOTES } from "../util/index.js";
 
 const mayCorrectWhitespace = attrName =>

--- a/src/print/BinaryExpression.js
+++ b/src/print/BinaryExpression.js
@@ -1,6 +1,6 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
-import { extension as coreExtension } from "melody-extension-core";
+import { Node } from "../melody/melody-types/index.js";
+import { extension as coreExtension } from "../melody/melody-extension-core/index.js";
 import {
     EXPRESSION_NEEDED,
     STRING_NEEDS_QUOTES,

--- a/src/print/BlockStatement.js
+++ b/src/print/BlockStatement.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import { EXPRESSION_NEEDED, printChildBlock } from "../util/index.js";
 
 const { hardline, group } = doc.builders;

--- a/src/print/CallExpression.js
+++ b/src/print/CallExpression.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     EXPRESSION_NEEDED,
     STRING_NEEDS_QUOTES,

--- a/src/print/ExpressionStatement.js
+++ b/src/print/ExpressionStatement.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     EXPRESSION_NEEDED,
     STRING_NEEDS_QUOTES,

--- a/src/print/FilterExpression.js
+++ b/src/print/FilterExpression.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     EXPRESSION_NEEDED,
     INSIDE_OF_STRING,

--- a/src/print/GenericTwigTag.js
+++ b/src/print/GenericTwigTag.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     STRING_NEEDS_QUOTES,
     indentWithHardline,

--- a/src/print/IfStatement.js
+++ b/src/print/IfStatement.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     printChildBlock,
     hasNoNewlines,

--- a/src/print/ObjectProperty.js
+++ b/src/print/ObjectProperty.js
@@ -1,4 +1,4 @@
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import { isValidIdentifierName, STRING_NEEDS_QUOTES } from "../util/index.js";
 
 const p = (node, path, print, options) => {

--- a/src/print/SetStatement.js
+++ b/src/print/SetStatement.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     printChildBlock,
     isNotExpression,

--- a/src/print/SwitchTag.js
+++ b/src/print/SwitchTag.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     STRING_NEEDS_QUOTES,
     printSingleTwigTag,

--- a/src/print/UnarySubclass.js
+++ b/src/print/UnarySubclass.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     firstValueInAncestorChain,
     findParentNode,

--- a/src/util/printFunctions.js
+++ b/src/util/printFunctions.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 
 const { line, indent, group } = doc.builders;
 

--- a/src/util/publicFunctions.js
+++ b/src/util/publicFunctions.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { Node } from "melody-types";
+import { Node } from "../melody/melody-types/index.js";
 import {
     EXPRESSION_NEEDED,
     INSIDE_OF_STRING,

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,10 +584,10 @@ babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.8.0:
+babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
+  integrity sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==
   dependencies:
     babel-runtime "^6.26.0"
     babel-traverse "^6.26.0"
@@ -610,7 +610,7 @@ babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.26.0, babel-types@^6.8.1:
+babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
@@ -1400,7 +1400,7 @@ hasown@^2.0.0, hasown@^2.0.1:
   dependencies:
     function-bind "^1.1.2"
 
-he@^1.1.0:
+he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -1685,7 +1685,12 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.12.0, lodash@^4.15.0, lodash@^4.17.4:
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -1717,44 +1722,6 @@ magic-string@^0.30.5:
   integrity sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
-
-melody-code-frame@^1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/melody-code-frame/-/melody-code-frame-1.7.5.tgz#047eaebfc09c26ab9fcc57c0470b34b46312245a"
-  integrity sha512-q/Do+7ZFxRHLN7IhT5RIJrTKh7xNmX3JG4+AD1ZST9iB8gUPYs6yfgGexDRDvtOAAGgLfFbT1DlMWJtldqYaPQ==
-  dependencies:
-    lodash "^4.15.0"
-
-melody-extension-core@^1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/melody-extension-core/-/melody-extension-core-1.7.5.tgz#85b7fc2aaf436e4b7cdc212212eff00d3a81ba08"
-  integrity sha512-eu/ji2sxpKvob03+1bdtuRr9XTW/VdogjHXvHiMYIK5DslpREcdGLVDEVAa1dfnnzoKGso76XCOHTJy0pImRfg==
-  dependencies:
-    babel-template "^6.8.0"
-    babel-types "^6.8.1"
-    lodash "^4.12.0"
-    shortid "^2.2.6"
-
-melody-parser@^1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/melody-parser/-/melody-parser-1.7.5.tgz#6f10e02f194159792a2f83d51e8790ba6ce71141"
-  integrity sha512-ffWDWl76G3lgTQUZ3SqGY0oZeul9FrKAnV+8+j3+afrS7AjBC32w5H+Imi00+qcOgdkpoU3eWwisqKc+pQmQ8g==
-  dependencies:
-    he "^1.1.0"
-    lodash "^4.12.0"
-    melody-code-frame "^1.7.5"
-
-melody-traverse@^1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/melody-traverse/-/melody-traverse-1.7.5.tgz#b40b80331c47aa483b477c7fbebd1400e21d8e59"
-  integrity sha512-k9agECp5qEyIDybedgMNHPalb6wfwy5WlczJriOAn/swggeoq3+HojXSABo3uKM7K8xXNmpVhW/wOJA86oqjIQ==
-
-melody-types@^1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/melody-types/-/melody-types-1.7.5.tgz#6de13f2c6f9504db890a3261a49fc18a26e31018"
-  integrity sha512-KkZmYlkmHtK10Hyx0mVNBZg1OXctIzZo2w3Vyc5AOV+KLA5lRiG6Z3Lp+G8o1LD6UZY0PC83/57hw3gs2Qj+Tg==
-  dependencies:
-    babel-types "^6.8.1"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -1822,11 +1789,6 @@ ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-nanoid@^2.1.0:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.8.tgz#2dbb0224231b246e3b4c819de7bfea6384dabf08"
-  integrity sha512-g1z+n5s26w0TGKh7gjn7HCqurNKMZWzH08elXzh/gM/csQHd/UqDV6uxMghQYg9IvqRPm1QpeMk50YMofHvEjQ==
 
 nanoid@^3.3.7:
   version "3.3.7"
@@ -2205,13 +2167,6 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
-shortid@^2.2.6:
-  version "2.2.15"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
-  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
-  dependencies:
-    nanoid "^2.1.0"
 
 side-channel@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
Well this was quite the journey.

Whilst this was relatively trivial, there was quite a lot of work to be done to wrangle this together.

Summary of changes
- All melody-* dependencies have been removed
- A new ./src/melody/ directory has been created to house these dependencies directly in the project
- Each package has the contents of the src dir added to a subdir of the new melody directory
- Any necessary dependencies of these packages are now dependencies of this project (babel-template, he and lodash)
- All imports/exports have been updated to work with the local version of these dependencies
- Any typescript features from the original melody packages have been converted to JSDoc to avoid adding a build step