### PR TITLE
Partially import melody project into core

### DIFF
--- a/src/melody/melody-code-frame/index.js
+++ b/src/melody/melody-code-frame/index.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import lineNumbers from './lineNumbers';
+import { repeat } from 'lodash';
+
+const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
+
+export default function({ rawLines, lineNumber, colNumber, length }) {
+    const lines = rawLines.split(NEWLINE),
+        start = Math.max(lineNumber - 3, 0),
+        end = Math.min(lineNumber + 3, lines.length);
+
+    return lineNumbers(lines.slice(start, end), {
+        start: start + 1,
+        before: '  ',
+        after: ' | ',
+        transform(params) {
+            if (params.number !== lineNumber) {
+                return;
+            }
+
+            if (typeof colNumber === 'number') {
+                params.line += `\n${params.before}${repeat(' ', params.width)}${
+                    params.after
+                }${repeat(' ', colNumber)}${repeat('^', length)}`;
+            }
+
+            params.before = params.before.replace(/^./, '>');
+        },
+    }).join('\n');
+}

--- a/src/melody/melody-code-frame/lineNumbers.js
+++ b/src/melody/melody-code-frame/lineNumbers.js
@@ -1,0 +1,45 @@
+// Copyright 2014, 2015 Simon Lydell
+// X11 (“MIT”) Licensed. (See LICENSE.)
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { padStart } from 'lodash';
+
+const get = options => (key, defaultValue) =>
+    key in options ? options[key] : defaultValue;
+
+function lineNumbers(lines, options) {
+    const getOption = get(options);
+    const transform = getOption('transform', Function.prototype);
+    const padding = getOption('padding', ' ');
+    const before = getOption('before', ' ');
+    const after = getOption('after', ' | ');
+    const start = getOption('start', 1);
+    const end = start + lines.length - 1;
+    const width = String(end).length;
+    return lines.map(function(line, index) {
+        const number = start + index;
+        const params = { before, number, width, after, line };
+        transform(params);
+        return (
+            params.before +
+            padStart(params.number, width, padding) +
+            params.after +
+            params.line
+        );
+    });
+}
+
+export default lineNumbers;

--- a/src/melody/melody-extension-core/index.js
+++ b/src/melody/melody-extension-core/index.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { unaryOperators, binaryOperators, tests } from './operators';
+import { AutoescapeParser } from './parser/autoescape';
+import { BlockParser } from './parser/block';
+import { DoParser } from './parser/do';
+import { EmbedParser } from './parser/embed';
+import { ExtendsParser } from './parser/extends';
+import { FilterParser } from './parser/filter';
+import { FlushParser } from './parser/flush';
+import { ForParser } from './parser/for';
+import { FromParser } from './parser/from';
+import { IfParser } from './parser/if';
+import { ImportParser } from './parser/import';
+import { IncludeParser } from './parser/include';
+import { MacroParser } from './parser/macro';
+import { SetParser } from './parser/set';
+import { SpacelessParser } from './parser/spaceless';
+import { UseParser } from './parser/use';
+import { MountParser } from './parser/mount';
+
+import forVisitor from './visitors/for';
+import testVisitor from './visitors/tests';
+import filters from './visitors/filters';
+import functions from './visitors/functions';
+
+const filterMap = [
+    'attrs',
+    'classes',
+    'styles',
+    'batch',
+    'escape',
+    'format',
+    'merge',
+    'nl2br',
+    'number_format',
+    'raw',
+    'replace',
+    'reverse',
+    'round',
+    'striptags',
+    'title',
+    'url_encode',
+    'trim',
+].reduce((map, filterName) => {
+    map[filterName] = 'melody-runtime';
+    return map;
+}, Object.create(null));
+
+Object.assign(filterMap, filters);
+
+const functionMap = [
+    'attribute',
+    'constant',
+    'cycle',
+    'date',
+    'max',
+    'min',
+    'random',
+    'range',
+    'source',
+    'template_from_string',
+].reduce((map, functionName) => {
+    map[functionName] = 'melody-runtime';
+    return map;
+}, Object.create(null));
+Object.assign(functionMap, functions);
+
+export const extension = {
+    tags: [
+        AutoescapeParser,
+        BlockParser,
+        DoParser,
+        EmbedParser,
+        ExtendsParser,
+        FilterParser,
+        FlushParser,
+        ForParser,
+        FromParser,
+        IfParser,
+        ImportParser,
+        IncludeParser,
+        MacroParser,
+        SetParser,
+        SpacelessParser,
+        UseParser,
+        MountParser,
+    ],
+    unaryOperators,
+    binaryOperators,
+    tests,
+    visitors: [forVisitor, testVisitor],
+    filterMap,
+    functionMap,
+};
+
+export {
+    AutoescapeBlock,
+    BlockStatement,
+    BlockCallExpression,
+    MountStatement,
+    DoStatement,
+    EmbedStatement,
+    ExtendsStatement,
+    FilterBlockStatement,
+    FlushStatement,
+    ForStatement,
+    ImportDeclaration,
+    FromStatement,
+    IfStatement,
+    IncludeStatement,
+    MacroDeclarationStatement,
+    VariableDeclarationStatement,
+    SetStatement,
+    SpacelessBlock,
+    AliasExpression,
+    UseStatement,
+    UnaryNotExpression,
+    UnaryNeqExpression,
+    UnaryPosExpression,
+    BinaryOrExpression,
+    BinaryAndExpression,
+    BitwiseOrExpression,
+    BitwiseXorExpression,
+    BitwiseAndExpression,
+    BinaryEqualsExpression,
+    BinaryNotEqualsExpression,
+    BinaryLessThanExpression,
+    BinaryGreaterThanExpression,
+    BinaryLessThanOrEqualExpression,
+    BinaryGreaterThanOrEqualExpression,
+    BinaryNotInExpression,
+    BinaryInExpression,
+    BinaryMatchesExpression,
+    BinaryStartsWithExpression,
+    BinaryEndsWithExpression,
+    BinaryRangeExpression,
+    BinaryAddExpression,
+    BinaryMulExpression,
+    BinaryDivExpression,
+    BinaryFloorDivExpression,
+    BinaryModExpression,
+    BinaryPowerExpression,
+    BinaryNullCoalesceExpression,
+    TestEvenExpression,
+    TestOddExpression,
+    TestDefinedExpression,
+    TestSameAsExpression,
+    TestNullExpression,
+    TestDivisibleByExpression,
+    TestConstantExpression,
+    TestEmptyExpression,
+    TestIterableExpression,
+} from './types';

--- a/src/melody/melody-extension-core/operators.js
+++ b/src/melody/melody-extension-core/operators.js
@@ -1,0 +1,402 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Node,
+    BinaryExpression,
+    BinaryConcatExpression,
+    UnaryExpression,
+    type,
+    alias,
+    visitor,
+} from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    copyStart,
+    copyEnd,
+    copyLoc,
+    LEFT,
+} from 'melody-parser';
+
+export const unaryOperators = [];
+export const binaryOperators = [];
+export const tests = [];
+
+//region Unary Expressions
+export const UnaryNotExpression = createUnaryOperator(
+    'not',
+    'UnaryNotExpression',
+    50
+);
+export const UnaryNeqExpression = createUnaryOperator(
+    '-',
+    'UnaryNeqExpression',
+    500
+);
+export const UnaryPosExpression = createUnaryOperator(
+    '+',
+    'UnaryPosExpression',
+    500
+);
+//endregion
+
+//region Binary Expressions
+export const BinaryOrExpression = createBinaryOperatorNode({
+    text: 'or',
+    type: 'BinaryOrExpression',
+    precedence: 10,
+    associativity: LEFT,
+});
+export const BinaryAndExpression = createBinaryOperatorNode({
+    text: 'and',
+    type: 'BinaryAndExpression',
+    precedence: 15,
+    associativity: LEFT,
+});
+
+export const BitwiseOrExpression = createBinaryOperatorNode({
+    text: 'b-or',
+    type: 'BitwiseOrExpression',
+    precedence: 16,
+    associativity: LEFT,
+});
+export const BitwiseXorExpression = createBinaryOperatorNode({
+    text: 'b-xor',
+    type: 'BitwiseXOrExpression',
+    precedence: 17,
+    associativity: LEFT,
+});
+export const BitwiseAndExpression = createBinaryOperatorNode({
+    text: 'b-and',
+    type: 'BitwiseAndExpression',
+    precedence: 18,
+    associativity: LEFT,
+});
+
+export const BinaryEqualsExpression = createBinaryOperatorNode({
+    text: '==',
+    type: 'BinaryEqualsExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryNotEqualsExpression = createBinaryOperatorNode({
+    text: '!=',
+    type: 'BinaryNotEqualsExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryLessThanExpression = createBinaryOperatorNode({
+    text: '<',
+    type: 'BinaryLessThanExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryGreaterThanExpression = createBinaryOperatorNode({
+    text: '>',
+    type: 'BinaryGreaterThanExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryLessThanOrEqualExpression = createBinaryOperatorNode({
+    text: '<=',
+    type: 'BinaryLessThanOrEqualExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryGreaterThanOrEqualExpression = createBinaryOperatorNode({
+    text: '>=',
+    type: 'BinaryGreaterThanOrEqualExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+
+export const BinaryNotInExpression = createBinaryOperatorNode({
+    text: 'not in',
+    type: 'BinaryNotInExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryInExpression = createBinaryOperatorNode({
+    text: 'in',
+    type: 'BinaryInExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryMatchesExpression = createBinaryOperatorNode({
+    text: 'matches',
+    type: 'BinaryMatchesExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryStartsWithExpression = createBinaryOperatorNode({
+    text: 'starts with',
+    type: 'BinaryStartsWithExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+export const BinaryEndsWithExpression = createBinaryOperatorNode({
+    text: 'ends with',
+    type: 'BinaryEndsWithExpression',
+    precedence: 20,
+    associativity: LEFT,
+});
+
+export const BinaryRangeExpression = createBinaryOperatorNode({
+    text: '..',
+    type: 'BinaryRangeExpression',
+    precedence: 25,
+    associativity: LEFT,
+});
+
+export const BinaryAddExpression = createBinaryOperatorNode({
+    text: '+',
+    type: 'BinaryAddExpression',
+    precedence: 30,
+    associativity: LEFT,
+});
+export const BinarySubExpression = createBinaryOperatorNode({
+    text: '-',
+    type: 'BinarySubExpression',
+    precedence: 30,
+    associativity: LEFT,
+});
+binaryOperators.push({
+    text: '~',
+    precedence: 40,
+    associativity: LEFT,
+    createNode(token, lhs, rhs) {
+        const op = new BinaryConcatExpression(lhs, rhs);
+        copyStart(op, lhs);
+        copyEnd(op, rhs);
+        return op;
+    },
+});
+export const BinaryMulExpression = createBinaryOperatorNode({
+    text: '*',
+    type: 'BinaryMulExpression',
+    precedence: 60,
+    associativity: LEFT,
+});
+export const BinaryDivExpression = createBinaryOperatorNode({
+    text: '/',
+    type: 'BinaryDivExpression',
+    precedence: 60,
+    associativity: LEFT,
+});
+export const BinaryFloorDivExpression = createBinaryOperatorNode({
+    text: '//',
+    type: 'BinaryFloorDivExpression',
+    precedence: 60,
+    associativity: LEFT,
+});
+export const BinaryModExpression = createBinaryOperatorNode({
+    text: '%',
+    type: 'BinaryModExpression',
+    precedence: 60,
+    associativity: LEFT,
+});
+
+binaryOperators.push({
+    text: 'is',
+    precedence: 100,
+    associativity: LEFT,
+    parse(parser, token, expr) {
+        const tokens = parser.tokens;
+
+        let not = false;
+        if (tokens.nextIf(Types.OPERATOR, 'not')) {
+            not = true;
+        }
+
+        const test = getTest(parser);
+        let args = null;
+        if (tokens.test(Types.LPAREN)) {
+            args = parser.matchArguments();
+        }
+        const testExpression = test.createNode(expr, args);
+        setStartFromToken(testExpression, token);
+        setEndFromToken(testExpression, tokens.la(-1));
+        if (not) {
+            return copyLoc(
+                new UnaryNotExpression(testExpression),
+                testExpression
+            );
+        }
+        return testExpression;
+    },
+});
+
+function getTest(parser) {
+    const tokens = parser.tokens;
+    const nameToken = tokens.la(0);
+    if (nameToken.type !== Types.NULL) {
+        tokens.expect(Types.SYMBOL);
+    } else {
+        tokens.next();
+    }
+    let testName = nameToken.text;
+    if (!parser.hasTest(testName)) {
+        // try 2-words tests
+        const continuedNameToken = tokens.expect(Types.SYMBOL);
+        testName += ' ' + continuedNameToken.text;
+        if (!parser.hasTest(testName)) {
+            parser.error({
+                title: `Unknown test "${testName}"`,
+                pos: nameToken.pos,
+            });
+        }
+    }
+
+    return parser.getTest(testName);
+}
+
+export const BinaryPowerExpression = createBinaryOperatorNode({
+    text: '**',
+    type: 'BinaryPowerExpression',
+    precedence: 200,
+    associativity: LEFT,
+});
+export const BinaryNullCoalesceExpression = createBinaryOperatorNode({
+    text: '??',
+    type: 'BinaryNullCoalesceExpression',
+    precedence: 300,
+    associativity: LEFT,
+});
+//endregion
+
+//region Test Expressions
+export const TestEvenExpression = createTest('even', 'TestEvenExpression');
+export const TestOddExpression = createTest('odd', 'TestOddExpression');
+export const TestDefinedExpression = createTest(
+    'defined',
+    'TestDefinedExpression'
+);
+export const TestSameAsExpression = createTest(
+    'same as',
+    'TestSameAsExpression'
+);
+tests.push({
+    text: 'sameas',
+    createNode(expr, args) {
+        // todo: add deprecation warning
+        return new TestSameAsExpression(expr, args);
+    },
+});
+export const TestNullExpression = createTest('null', 'TestNullExpression');
+tests.push({
+    text: 'none',
+    createNode(expr, args) {
+        return new TestNullExpression(expr, args);
+    },
+});
+export const TestDivisibleByExpression = createTest(
+    'divisible by',
+    'TestDivisibleByExpression'
+);
+tests.push({
+    text: 'divisibleby',
+    createNode(expr, args) {
+        // todo: add deprecation warning
+        return new TestDivisibleByExpression(expr, args);
+    },
+});
+export const TestConstantExpression = createTest(
+    'constant',
+    'TestConstantExpression'
+);
+export const TestEmptyExpression = createTest('empty', 'TestEmptyExpression');
+export const TestIterableExpression = createTest(
+    'iterable',
+    'TestIterableExpression'
+);
+//endregion
+
+//region Utilities
+function createTest(text, typeName) {
+    const TestExpression = class extends Node {
+        constructor(expr: Node, args?: Array<Node>) {
+            super();
+            this.expression = expr;
+            this.arguments = args;
+        }
+    };
+    type(TestExpression, typeName);
+    alias(TestExpression, 'Expression', 'TestExpression');
+    visitor(TestExpression, 'expression', 'arguments');
+
+    tests.push({
+        text,
+        createNode(expr, args) {
+            return new TestExpression(expr, args);
+        },
+    });
+
+    return TestExpression;
+}
+
+function createBinaryOperatorNode(options) {
+    const { text, precedence, associativity } = options;
+    const BinarySubclass = class extends BinaryExpression {
+        constructor(left: Node, right: Node) {
+            super(text, left, right);
+        }
+    };
+    type(BinarySubclass, options.type);
+    alias(BinarySubclass, 'BinaryExpression', 'Binary', 'Expression');
+    visitor(BinarySubclass, 'left', 'right');
+
+    const operator = {
+        text,
+        precedence,
+        associativity,
+    };
+    if (options.parse) {
+        operator.parse = options.parse;
+    } else if (options.createNode) {
+        operator.createNode = options.createNode;
+    } else {
+        operator.createNode = (token, lhs, rhs) => new BinarySubclass(lhs, rhs);
+    }
+    binaryOperators.push(operator);
+
+    return BinarySubclass;
+}
+
+function createUnaryOperator(operator, typeName, precedence) {
+    const UnarySubclass = class extends UnaryExpression {
+        constructor(argument: Node) {
+            super(operator, argument);
+        }
+    };
+    type(UnarySubclass, typeName);
+    alias(UnarySubclass, 'Expression', 'UnaryLike');
+    visitor(UnarySubclass, 'argument');
+
+    unaryOperators.push({
+        text: operator,
+        precedence,
+        createNode(token, expr) {
+            const op = new UnarySubclass(expr);
+            setStartFromToken(op, token);
+            copyEnd(op, expr);
+            return op;
+        },
+    });
+
+    return UnarySubclass;
+}
+//endregion

--- a/src/melody/melody-extension-core/parser/autoescape.js
+++ b/src/melody/melody-extension-core/parser/autoescape.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { AutoescapeBlock } from './../types';
+
+export const AutoescapeParser = {
+    name: 'autoescape',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        let escapeType = null,
+            stringStartToken,
+            openingTagEndToken,
+            closingTagStartToken;
+        if (tokens.nextIf(Types.TAG_END)) {
+            openingTagEndToken = tokens.la(-1);
+            escapeType = null;
+        } else if ((stringStartToken = tokens.nextIf(Types.STRING_START))) {
+            escapeType = tokens.expect(Types.STRING).text;
+            if (!tokens.nextIf(Types.STRING_END)) {
+                parser.error({
+                    title:
+                        'autoescape type declaration must be a simple string',
+                    pos: tokens.la(0).pos,
+                    advice: `The type declaration for autoescape must be a simple string such as 'html' or 'js'.
+I expected the current string to end with a ${
+                        stringStartToken.text
+                    } but instead found ${Types.ERROR_TABLE[tokens.lat(0)] ||
+                        tokens.lat(0)}.`,
+                });
+            }
+            openingTagEndToken = tokens.la(0);
+        } else if (tokens.nextIf(Types.FALSE)) {
+            escapeType = false;
+            openingTagEndToken = tokens.la(0);
+        } else if (tokens.nextIf(Types.TRUE)) {
+            escapeType = true;
+            openingTagEndToken = tokens.la(0);
+        } else {
+            parser.error({
+                title: 'Invalid autoescape type declaration',
+                pos: tokens.la(0).pos,
+                advice: `Expected type of autoescape to be a string, boolean or not specified. Found ${
+                    tokens.la(0).type
+                } instead.`,
+            });
+        }
+
+        const autoescape = new AutoescapeBlock(escapeType);
+        setStartFromToken(autoescape, token);
+        let tagEndToken;
+        autoescape.expressions = parser.parse((_, token, tokens) => {
+            if (
+                token.type === Types.TAG_START &&
+                tokens.nextIf(Types.SYMBOL, 'endautoescape')
+            ) {
+                closingTagStartToken = token;
+                tagEndToken = tokens.expect(Types.TAG_END);
+                return true;
+            }
+            return false;
+        }).expressions;
+        setEndFromToken(autoescape, tagEndToken);
+
+        autoescape.trimRightAutoescape = hasTagEndTokenTrimRight(
+            openingTagEndToken
+        );
+        autoescape.trimLeftEndautoescape = hasTagStartTokenTrimLeft(
+            closingTagStartToken
+        );
+
+        return autoescape;
+    },
+};

--- a/src/melody/melody-extension-core/parser/block.js
+++ b/src/melody/melody-extension-core/parser/block.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier, PrintExpressionStatement } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { BlockStatement } from './../types';
+
+export const BlockParser = {
+    name: 'block',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            nameToken = tokens.expect(Types.SYMBOL);
+
+        let blockStatement, openingTagEndToken, closingTagStartToken;
+        if ((openingTagEndToken = tokens.nextIf(Types.TAG_END))) {
+            blockStatement = new BlockStatement(
+                createNode(Identifier, nameToken, nameToken.text),
+                parser.parse((tokenText, token, tokens) => {
+                    const result = !!(
+                        token.type === Types.TAG_START &&
+                        tokens.nextIf(Types.SYMBOL, 'endblock')
+                    );
+                    if (result) {
+                        closingTagStartToken = token;
+                    }
+                    return result;
+                }).expressions
+            );
+
+            if (tokens.nextIf(Types.SYMBOL, nameToken.text)) {
+                if (tokens.lat(0) !== Types.TAG_END) {
+                    const unexpectedToken = tokens.next();
+                    parser.error({
+                        title: 'Block name mismatch',
+                        pos: unexpectedToken.pos,
+                        advice:
+                            unexpectedToken.type == Types.SYMBOL
+                                ? `Expected end of block ${
+                                      nameToken.text
+                                  } but instead found end of block ${
+                                      tokens.la(0).text
+                                  }.`
+                                : `endblock must be followed by either '%}' or the name of the open block. Found a token of type ${Types
+                                      .ERROR_TABLE[unexpectedToken.type] ||
+                                      unexpectedToken.type} instead.`,
+                    });
+                }
+            }
+        } else {
+            blockStatement = new BlockStatement(
+                createNode(Identifier, nameToken, nameToken.text),
+                new PrintExpressionStatement(parser.matchExpression())
+            );
+        }
+
+        setStartFromToken(blockStatement, token);
+        setEndFromToken(blockStatement, tokens.expect(Types.TAG_END));
+
+        blockStatement.trimRightBlock =
+            openingTagEndToken && hasTagEndTokenTrimRight(openingTagEndToken);
+        blockStatement.trimLeftEndblock = !!(
+            closingTagStartToken &&
+            hasTagStartTokenTrimLeft(closingTagStartToken)
+        );
+
+        return blockStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/do.js
+++ b/src/melody/melody-extension-core/parser/do.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
+import { DoStatement } from './../types';
+
+export const DoParser = {
+    name: 'do',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            doStatement = new DoStatement(parser.matchExpression());
+        setStartFromToken(doStatement, token);
+        setEndFromToken(doStatement, tokens.expect(Types.TAG_END));
+        return doStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/embed.js
+++ b/src/melody/melody-extension-core/parser/embed.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Node } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { filter } from 'lodash';
+import { EmbedStatement } from './../types';
+
+export const EmbedParser = {
+    name: 'embed',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        const embedStatement = new EmbedStatement(parser.matchExpression());
+
+        if (tokens.nextIf(Types.SYMBOL, 'ignore')) {
+            tokens.expect(Types.SYMBOL, 'missing');
+            embedStatement.ignoreMissing = true;
+        }
+
+        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+            embedStatement.argument = parser.matchExpression();
+        }
+
+        if (tokens.nextIf(Types.SYMBOL, 'only')) {
+            embedStatement.contextFree = true;
+        }
+
+        tokens.expect(Types.TAG_END);
+        const openingTagEndToken = tokens.la(-1);
+        let closingTagStartToken;
+
+        embedStatement.blocks = filter(
+            parser.parse((tokenText, token, tokens) => {
+                const result = !!(
+                    token.type === Types.TAG_START &&
+                    tokens.nextIf(Types.SYMBOL, 'endembed')
+                );
+                if (result) {
+                    closingTagStartToken = token;
+                }
+                return result;
+            }).expressions,
+            Node.isBlockStatement
+        );
+
+        setStartFromToken(embedStatement, token);
+        setEndFromToken(embedStatement, tokens.expect(Types.TAG_END));
+
+        embedStatement.trimRightEmbed = hasTagEndTokenTrimRight(
+            openingTagEndToken
+        );
+        embedStatement.trimLeftEndembed =
+            closingTagStartToken &&
+            hasTagStartTokenTrimLeft(closingTagStartToken);
+
+        return embedStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/extends.js
+++ b/src/melody/melody-extension-core/parser/extends.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
+import { ExtendsStatement } from './../types';
+
+export const ExtendsParser = {
+    name: 'extends',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        const extendsStatement = new ExtendsStatement(parser.matchExpression());
+
+        setStartFromToken(extendsStatement, token);
+        setEndFromToken(extendsStatement, tokens.expect(Types.TAG_END));
+
+        return extendsStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/filter.js
+++ b/src/melody/melody-extension-core/parser/filter.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { FilterBlockStatement } from './../types';
+
+export const FilterParser = {
+    name: 'filter',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            ref = createNode(Identifier, token, 'filter'),
+            filterExpression = parser.matchFilterExpression(ref);
+        tokens.expect(Types.TAG_END);
+        const openingTagEndToken = tokens.la(-1);
+        let closingTagStartToken;
+
+        const body = parser.parse((text, token, tokens) => {
+            const result =
+                token.type === Types.TAG_START &&
+                tokens.nextIf(Types.SYMBOL, 'endfilter');
+
+            if (result) {
+                closingTagStartToken = token;
+            }
+            return result;
+        }).expressions;
+
+        const filterBlockStatement = new FilterBlockStatement(
+            filterExpression,
+            body
+        );
+        setStartFromToken(filterBlockStatement, token);
+        setEndFromToken(filterBlockStatement, tokens.expect(Types.TAG_END));
+
+        filterBlockStatement.trimRightFilter = hasTagEndTokenTrimRight(
+            openingTagEndToken
+        );
+        filterBlockStatement.trimLeftEndfilter =
+            closingTagStartToken &&
+            hasTagStartTokenTrimLeft(closingTagStartToken);
+
+        return filterBlockStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/flush.js
+++ b/src/melody/melody-extension-core/parser/flush.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
+import { FlushStatement } from './../types';
+
+export const FlushParser = {
+    name: 'flush',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            flushStatement = new FlushStatement();
+
+        setStartFromToken(flushStatement, token);
+        setEndFromToken(flushStatement, tokens.expect(Types.TAG_END));
+        return flushStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/for.js
+++ b/src/melody/melody-extension-core/parser/for.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { ForStatement } from './../types';
+
+export const ForParser = {
+    name: 'for',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            forStatement = new ForStatement();
+
+        const keyTarget = tokens.expect(Types.SYMBOL);
+        if (tokens.nextIf(Types.COMMA)) {
+            forStatement.keyTarget = createNode(
+                Identifier,
+                keyTarget,
+                keyTarget.text
+            );
+            const valueTarget = tokens.expect(Types.SYMBOL);
+            forStatement.valueTarget = createNode(
+                Identifier,
+                valueTarget,
+                valueTarget.text
+            );
+        } else {
+            forStatement.keyTarget = null;
+            forStatement.valueTarget = createNode(
+                Identifier,
+                keyTarget,
+                keyTarget.text
+            );
+        }
+
+        tokens.expect(Types.OPERATOR, 'in');
+
+        forStatement.sequence = parser.matchExpression();
+
+        if (tokens.nextIf(Types.SYMBOL, 'if')) {
+            forStatement.condition = parser.matchExpression();
+        }
+
+        tokens.expect(Types.TAG_END);
+
+        const openingTagEndToken = tokens.la(-1);
+        let elseTagStartToken, elseTagEndToken;
+
+        forStatement.body = parser.parse((tokenText, token, tokens) => {
+            const result =
+                token.type === Types.TAG_START &&
+                (tokens.test(Types.SYMBOL, 'else') ||
+                    tokens.test(Types.SYMBOL, 'endfor'));
+            if (result && tokens.test(Types.SYMBOL, 'else')) {
+                elseTagStartToken = token;
+            }
+            return result;
+        });
+
+        if (tokens.nextIf(Types.SYMBOL, 'else')) {
+            tokens.expect(Types.TAG_END);
+            elseTagEndToken = tokens.la(-1);
+            forStatement.otherwise = parser.parse(
+                (tokenText, token, tokens) => {
+                    return (
+                        token.type === Types.TAG_START &&
+                        tokens.test(Types.SYMBOL, 'endfor')
+                    );
+                }
+            );
+        }
+        const endforTagStartToken = tokens.la(-1);
+        tokens.expect(Types.SYMBOL, 'endfor');
+
+        setStartFromToken(forStatement, token);
+        setEndFromToken(forStatement, tokens.expect(Types.TAG_END));
+
+        forStatement.trimRightFor = hasTagEndTokenTrimRight(openingTagEndToken);
+        forStatement.trimLeftElse = !!(
+            elseTagStartToken && hasTagStartTokenTrimLeft(elseTagStartToken)
+        );
+        forStatement.trimRightElse = !!(
+            elseTagEndToken && hasTagEndTokenTrimRight(elseTagEndToken)
+        );
+        forStatement.trimLeftEndfor = hasTagStartTokenTrimLeft(
+            endforTagStartToken
+        );
+
+        return forStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/from.js
+++ b/src/melody/melody-extension-core/parser/from.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+} from 'melody-parser';
+import { ImportDeclaration, FromStatement } from './../types';
+
+export const FromParser = {
+    name: 'from',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            source = parser.matchExpression(),
+            imports = [];
+
+        tokens.expect(Types.SYMBOL, 'import');
+
+        do {
+            const name = tokens.expect(Types.SYMBOL);
+
+            let alias = name;
+            if (tokens.nextIf(Types.SYMBOL, 'as')) {
+                alias = tokens.expect(Types.SYMBOL);
+            }
+
+            const importDeclaration = new ImportDeclaration(
+                createNode(Identifier, name, name.text),
+                createNode(Identifier, alias, alias.text)
+            );
+            setStartFromToken(importDeclaration, name);
+            setEndFromToken(importDeclaration, alias);
+
+            imports.push(importDeclaration);
+
+            if (!tokens.nextIf(Types.COMMA)) {
+                break;
+            }
+        } while (!tokens.test(Types.EOF));
+
+        const fromStatement = new FromStatement(source, imports);
+
+        setStartFromToken(fromStatement, token);
+        setEndFromToken(fromStatement, tokens.expect(Types.TAG_END));
+
+        return fromStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/if.js
+++ b/src/melody/melody-extension-core/parser/if.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { IfStatement } from './../types';
+
+export const IfParser = {
+    name: 'if',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+        let test = parser.matchExpression(),
+            alternate = null;
+
+        tokens.expect(Types.TAG_END);
+        const ifTagEndToken = tokens.la(-1);
+
+        const ifStatement = new IfStatement(
+            test,
+            parser.parse(matchConsequent).expressions
+        );
+
+        let elseTagStartToken,
+            elseTagEndToken,
+            elseifTagStartToken,
+            elseifTagEndToken;
+
+        do {
+            if (tokens.nextIf(Types.SYMBOL, 'else')) {
+                elseTagStartToken = tokens.la(-2);
+                tokens.expect(Types.TAG_END);
+                elseTagEndToken = tokens.la(-1);
+                (alternate || ifStatement).alternate = parser.parse(
+                    matchAlternate
+                ).expressions;
+            } else if (tokens.nextIf(Types.SYMBOL, 'elseif')) {
+                elseifTagStartToken = tokens.la(-2);
+                test = parser.matchExpression();
+                tokens.expect(Types.TAG_END);
+                elseifTagEndToken = tokens.la(-1);
+                const consequent = parser.parse(matchConsequent).expressions;
+                alternate = (
+                    alternate || ifStatement
+                ).alternate = new IfStatement(test, consequent);
+                alternate.trimLeft = hasTagStartTokenTrimLeft(
+                    elseifTagStartToken
+                );
+                alternate.trimRightIf = hasTagEndTokenTrimRight(
+                    elseifTagEndToken
+                );
+            }
+
+            if (tokens.nextIf(Types.SYMBOL, 'endif')) {
+                break;
+            }
+        } while (!tokens.test(Types.EOF));
+
+        const endifTagStartToken = tokens.la(-2);
+
+        setStartFromToken(ifStatement, token);
+        setEndFromToken(ifStatement, tokens.expect(Types.TAG_END));
+
+        ifStatement.trimRightIf = hasTagEndTokenTrimRight(ifTagEndToken);
+        ifStatement.trimLeftElse = !!(
+            elseTagStartToken && hasTagStartTokenTrimLeft(elseTagStartToken)
+        );
+        ifStatement.trimRightElse = !!(
+            elseTagEndToken && hasTagEndTokenTrimRight(elseTagEndToken)
+        );
+        ifStatement.trimLeftEndif = hasTagStartTokenTrimLeft(
+            endifTagStartToken
+        );
+
+        return ifStatement;
+    },
+};
+
+function matchConsequent(tokenText, token, tokens) {
+    if (token.type === Types.TAG_START) {
+        const next = tokens.la(0).text;
+        return next === 'else' || next === 'endif' || next === 'elseif';
+    }
+    return false;
+}
+
+function matchAlternate(tokenText, token, tokens) {
+    return token.type === Types.TAG_START && tokens.test(Types.SYMBOL, 'endif');
+}

--- a/src/melody/melody-extension-core/parser/import.js
+++ b/src/melody/melody-extension-core/parser/import.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+} from 'melody-parser';
+import { ImportDeclaration } from './../types';
+
+export const ImportParser = {
+    name: 'import',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            source = parser.matchExpression();
+
+        tokens.expect(Types.SYMBOL, 'as');
+        const alias = tokens.expect(Types.SYMBOL);
+
+        const importStatement = new ImportDeclaration(
+            source,
+            createNode(Identifier, alias, alias.text)
+        );
+
+        setStartFromToken(importStatement, token);
+        setEndFromToken(importStatement, tokens.expect(Types.TAG_END));
+
+        return importStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/include.js
+++ b/src/melody/melody-extension-core/parser/include.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Types, setStartFromToken, setEndFromToken } from 'melody-parser';
+import { IncludeStatement } from './../types';
+
+export const IncludeParser = {
+    name: 'include',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        const includeStatement = new IncludeStatement(parser.matchExpression());
+
+        if (tokens.nextIf(Types.SYMBOL, 'ignore')) {
+            tokens.expect(Types.SYMBOL, 'missing');
+            includeStatement.ignoreMissing = true;
+        }
+
+        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+            includeStatement.argument = parser.matchExpression();
+        }
+
+        if (tokens.nextIf(Types.SYMBOL, 'only')) {
+            includeStatement.contextFree = true;
+        }
+
+        setStartFromToken(includeStatement, token);
+        setEndFromToken(includeStatement, tokens.expect(Types.TAG_END));
+
+        return includeStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/macro.js
+++ b/src/melody/melody-extension-core/parser/macro.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { MacroDeclarationStatement } from './../types';
+
+export const MacroParser = {
+    name: 'macro',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        const nameToken = tokens.expect(Types.SYMBOL);
+        const args = [];
+
+        tokens.expect(Types.LPAREN);
+        while (!tokens.test(Types.RPAREN) && !tokens.test(Types.EOF)) {
+            const arg = tokens.expect(Types.SYMBOL);
+            args.push(createNode(Identifier, arg, arg.text));
+
+            if (!tokens.nextIf(Types.COMMA) && !tokens.test(Types.RPAREN)) {
+                // not followed by comma or rparen
+                parser.error({
+                    title: 'Expected comma or ")"',
+                    pos: tokens.la(0).pos,
+                    advice:
+                        'The argument list of a macro can only consist of parameter names separated by commas.',
+                });
+            }
+        }
+        tokens.expect(Types.RPAREN);
+
+        const openingTagEndToken = tokens.la(0);
+        let closingTagStartToken;
+
+        const body = parser.parse((tokenText, token, tokens) => {
+            const result = !!(
+                token.type === Types.TAG_START &&
+                tokens.nextIf(Types.SYMBOL, 'endmacro')
+            );
+            if (result) {
+                closingTagStartToken = token;
+            }
+            return result;
+        });
+
+        if (tokens.test(Types.SYMBOL)) {
+            var nameEndToken = tokens.next();
+            if (nameToken.text !== nameEndToken.text) {
+                parser.error({
+                    title: `Macro name mismatch, expected "${
+                        nameToken.text
+                    }" but found "${nameEndToken.text}"`,
+                    pos: nameEndToken.pos,
+                });
+            }
+        }
+
+        const macroDeclarationStatement = new MacroDeclarationStatement(
+            createNode(Identifier, nameToken, nameToken.text),
+            args,
+            body
+        );
+
+        setStartFromToken(macroDeclarationStatement, token);
+        setEndFromToken(
+            macroDeclarationStatement,
+            tokens.expect(Types.TAG_END)
+        );
+
+        macroDeclarationStatement.trimRightMacro = hasTagEndTokenTrimRight(
+            openingTagEndToken
+        );
+        macroDeclarationStatement.trimLeftEndmacro = hasTagStartTokenTrimLeft(
+            closingTagStartToken
+        );
+
+        return macroDeclarationStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/mount.js
+++ b/src/melody/melody-extension-core/parser/mount.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import { MountStatement } from '../types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+
+export const MountParser = {
+    name: 'mount',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        let name = null,
+            source = null,
+            key = null,
+            async = false,
+            delayBy = 0,
+            argument = null;
+
+        if (tokens.test(Types.SYMBOL, 'async')) {
+            // we might be looking at an async mount
+            const nextToken = tokens.la(1);
+            if (nextToken.type === Types.STRING_START) {
+                async = true;
+                tokens.next();
+            }
+        }
+
+        if (tokens.test(Types.STRING_START)) {
+            source = parser.matchStringExpression();
+        } else {
+            const nameToken = tokens.expect(Types.SYMBOL);
+            name = createNode(Identifier, nameToken, nameToken.text);
+            if (tokens.nextIf(Types.SYMBOL, 'from')) {
+                source = parser.matchStringExpression();
+            }
+        }
+
+        if (tokens.nextIf(Types.SYMBOL, 'as')) {
+            key = parser.matchExpression();
+        }
+
+        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+            argument = parser.matchExpression();
+        }
+
+        if (async) {
+            if (tokens.nextIf(Types.SYMBOL, 'delay')) {
+                tokens.expect(Types.SYMBOL, 'placeholder');
+                tokens.expect(Types.SYMBOL, 'by');
+                delayBy = Number.parseInt(tokens.expect(Types.NUMBER).text, 10);
+                if (tokens.nextIf(Types.SYMBOL, 's')) {
+                    delayBy *= 1000;
+                } else {
+                    tokens.expect(Types.SYMBOL, 'ms');
+                }
+            }
+        }
+
+        const mountStatement = new MountStatement(
+            name,
+            source,
+            key,
+            argument,
+            async,
+            delayBy
+        );
+
+        let openingTagEndToken,
+            catchTagStartToken,
+            catchTagEndToken,
+            endmountTagStartToken;
+
+        if (async) {
+            tokens.expect(Types.TAG_END);
+            openingTagEndToken = tokens.la(-1);
+
+            mountStatement.body = parser.parse((tokenText, token, tokens) => {
+                return (
+                    token.type === Types.TAG_START &&
+                    (tokens.test(Types.SYMBOL, 'catch') ||
+                        tokens.test(Types.SYMBOL, 'endmount'))
+                );
+            });
+
+            if (tokens.nextIf(Types.SYMBOL, 'catch')) {
+                catchTagStartToken = tokens.la(-2);
+                const errorVariableName = tokens.expect(Types.SYMBOL);
+                mountStatement.errorVariableName = createNode(
+                    Identifier,
+                    errorVariableName,
+                    errorVariableName.text
+                );
+                tokens.expect(Types.TAG_END);
+                catchTagEndToken = tokens.la(-1);
+                mountStatement.otherwise = parser.parse(
+                    (tokenText, token, tokens) => {
+                        return (
+                            token.type === Types.TAG_START &&
+                            tokens.test(Types.SYMBOL, 'endmount')
+                        );
+                    }
+                );
+            }
+            tokens.expect(Types.SYMBOL, 'endmount');
+            endmountTagStartToken = tokens.la(-2);
+        }
+
+        setStartFromToken(mountStatement, token);
+        setEndFromToken(mountStatement, tokens.expect(Types.TAG_END));
+
+        mountStatement.trimRightMount = !!(
+            openingTagEndToken && hasTagEndTokenTrimRight(openingTagEndToken)
+        );
+        mountStatement.trimLeftCatch = !!(
+            catchTagStartToken && hasTagStartTokenTrimLeft(catchTagStartToken)
+        );
+        mountStatement.trimRightCatch = !!(
+            catchTagEndToken && hasTagEndTokenTrimRight(catchTagEndToken)
+        );
+        mountStatement.trimLeftEndmount = !!(
+            endmountTagStartToken &&
+            hasTagStartTokenTrimLeft(endmountTagStartToken)
+        );
+
+        return mountStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/set.js
+++ b/src/melody/melody-extension-core/parser/set.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { VariableDeclarationStatement, SetStatement } from './../types';
+
+export const SetParser = {
+    name: 'set',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            names = [],
+            values = [];
+
+        let openingTagEndToken, closingTagStartToken;
+
+        do {
+            const name = tokens.expect(Types.SYMBOL);
+            names.push(createNode(Identifier, name, name.text));
+        } while (tokens.nextIf(Types.COMMA));
+
+        if (tokens.nextIf(Types.ASSIGNMENT)) {
+            do {
+                values.push(parser.matchExpression());
+            } while (tokens.nextIf(Types.COMMA));
+        } else {
+            if (names.length !== 1) {
+                parser.error({
+                    title: 'Illegal multi-set',
+                    pos: tokens.la(0).pos,
+                    advice:
+                        'When using set with a block, you cannot have multiple targets.',
+                });
+            }
+            tokens.expect(Types.TAG_END);
+            openingTagEndToken = tokens.la(-1);
+
+            values[0] = parser.parse((tokenText, token, tokens) => {
+                const result = !!(
+                    token.type === Types.TAG_START &&
+                    tokens.nextIf(Types.SYMBOL, 'endset')
+                );
+                if (result) {
+                    closingTagStartToken = token;
+                }
+                return result;
+            }).expressions;
+        }
+
+        if (names.length !== values.length) {
+            parser.error({
+                title: 'Mismatch of set names and values',
+                pos: token.pos,
+                advice: `When using set, you must ensure that the number of
+assigned variable names is identical to the supplied values. However, here I've found
+${names.length} variable names and ${values.length} values.`,
+            });
+        }
+
+        // now join names and values
+        const assignments = [];
+        for (let i = 0, len = names.length; i < len; i++) {
+            assignments[i] = new VariableDeclarationStatement(
+                names[i],
+                values[i]
+            );
+        }
+
+        const setStatement = new SetStatement(assignments);
+
+        setStartFromToken(setStatement, token);
+        setEndFromToken(setStatement, tokens.expect(Types.TAG_END));
+
+        setStatement.trimRightSet = !!(
+            openingTagEndToken && hasTagEndTokenTrimRight(openingTagEndToken)
+        );
+        setStatement.trimLeftEndset = !!(
+            closingTagStartToken &&
+            hasTagStartTokenTrimLeft(closingTagStartToken)
+        );
+
+        return setStatement;
+    },
+};

--- a/src/melody/melody-extension-core/parser/spaceless.js
+++ b/src/melody/melody-extension-core/parser/spaceless.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+} from 'melody-parser';
+import { SpacelessBlock } from './../types';
+
+export const SpacelessParser = {
+    name: 'spaceless',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        tokens.expect(Types.TAG_END);
+        const openingTagEndToken = tokens.la(-1);
+        let closingTagStartToken;
+
+        const body = parser.parse((tokenText, token, tokens) => {
+            const result = !!(
+                token.type === Types.TAG_START &&
+                tokens.nextIf(Types.SYMBOL, 'endspaceless')
+            );
+            closingTagStartToken = token;
+            return result;
+        }).expressions;
+
+        const spacelessBlock = new SpacelessBlock(body);
+        setStartFromToken(spacelessBlock, token);
+        setEndFromToken(spacelessBlock, tokens.expect(Types.TAG_END));
+
+        spacelessBlock.trimRightSpaceless = hasTagEndTokenTrimRight(
+            openingTagEndToken
+        );
+        spacelessBlock.trimLeftEndspaceless = !!(
+            closingTagStartToken &&
+            hasTagStartTokenTrimLeft(closingTagStartToken)
+        );
+
+        return spacelessBlock;
+    },
+};

--- a/src/melody/melody-extension-core/parser/use.js
+++ b/src/melody/melody-extension-core/parser/use.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Identifier } from 'melody-types';
+import {
+    Types,
+    setStartFromToken,
+    setEndFromToken,
+    copyStart,
+    copyEnd,
+    createNode,
+} from 'melody-parser';
+import { AliasExpression, UseStatement } from './../types';
+
+export const UseParser = {
+    name: 'use',
+    parse(parser, token) {
+        const tokens = parser.tokens;
+
+        const source = parser.matchExpression(),
+            aliases = [];
+
+        if (tokens.nextIf(Types.SYMBOL, 'with')) {
+            do {
+                const nameToken = tokens.expect(Types.SYMBOL),
+                    name = createNode(Identifier, nameToken, nameToken.text);
+                let alias = name;
+                if (tokens.nextIf(Types.SYMBOL, 'as')) {
+                    const aliasToken = tokens.expect(Types.SYMBOL);
+                    alias = createNode(Identifier, aliasToken, aliasToken.text);
+                }
+                const aliasExpression = new AliasExpression(name, alias);
+                copyStart(aliasExpression, name);
+                copyEnd(aliasExpression, alias);
+                aliases.push(aliasExpression);
+            } while (tokens.nextIf(Types.COMMA));
+        }
+
+        const useStatement = new UseStatement(source, aliases);
+
+        setStartFromToken(useStatement, token);
+        setEndFromToken(useStatement, tokens.expect(Types.TAG_END));
+
+        return useStatement;
+    },
+};

--- a/src/melody/melody-extension-core/types.js
+++ b/src/melody/melody-extension-core/types.js
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Node,
+    Identifier,
+    SequenceExpression,
+    type,
+    alias,
+    visitor,
+} from 'melody-types';
+import type { StringLiteral } from 'melody-types';
+
+export class AutoescapeBlock extends Node {
+    constructor(type: String | boolean, expressions?: Array<Node>) {
+        super();
+        this.escapeType = type;
+        this.expressions = expressions;
+    }
+}
+type(AutoescapeBlock, 'AutoescapeBlock');
+alias(AutoescapeBlock, 'Block', 'Escape');
+visitor(AutoescapeBlock, 'expressions');
+
+export class BlockStatement extends Node {
+    constructor(name: Identifier, body: Node) {
+        super();
+        this.name = name;
+        this.body = body;
+    }
+}
+type(BlockStatement, 'BlockStatement');
+alias(BlockStatement, 'Statement', 'Scope', 'RootScope');
+visitor(BlockStatement, 'body');
+
+export class BlockCallExpression extends Node {
+    constructor(callee: StringLiteral, args: Array<Node> = []) {
+        super();
+        this.callee = callee;
+        this.arguments = args;
+    }
+}
+type(BlockCallExpression, 'BlockCallExpression');
+alias(BlockCallExpression, 'Expression', 'FunctionInvocation');
+visitor(BlockCallExpression, 'arguments');
+
+export class MountStatement extends Node {
+    constructor(
+        name?: Identifier,
+        source?: String,
+        key?: Node,
+        argument?: Node,
+        async?: Boolean,
+        delayBy?: Number
+    ) {
+        super();
+        this.name = name;
+        this.source = source;
+        this.key = key;
+        this.argument = argument;
+        this.async = async;
+        this.delayBy = delayBy;
+        this.errorVariableName = null;
+        this.body = null;
+        this.otherwise = null;
+    }
+}
+type(MountStatement, 'MountStatement');
+alias(MountStatement, 'Statement', 'Scope');
+visitor(
+    MountStatement,
+    'name',
+    'source',
+    'key',
+    'argument',
+    'body',
+    'otherwise'
+);
+
+export class DoStatement extends Node {
+    constructor(expression: Node) {
+        super();
+        this.value = expression;
+    }
+}
+type(DoStatement, 'DoStatement');
+alias(DoStatement, 'Statement');
+visitor(DoStatement, 'value');
+
+export class EmbedStatement extends Node {
+    constructor(parent: Node) {
+        super();
+        this.parent = parent;
+        this.argument = null;
+        this.contextFree = false;
+        // when `true`, missing templates will be ignored
+        this.ignoreMissing = false;
+        this.blocks = null;
+    }
+}
+type(EmbedStatement, 'EmbedStatement');
+alias(EmbedStatement, 'Statement', 'Include');
+visitor(EmbedStatement, 'argument', 'blocks');
+
+export class ExtendsStatement extends Node {
+    constructor(parentName: Node) {
+        super();
+        this.parentName = parentName;
+    }
+}
+type(ExtendsStatement, 'ExtendsStatement');
+alias(ExtendsStatement, 'Statement', 'Include');
+visitor(ExtendsStatement, 'parentName');
+
+export class FilterBlockStatement extends Node {
+    constructor(filterExpression: Node, body: Node) {
+        super();
+        this.filterExpression = filterExpression;
+        this.body = body;
+    }
+}
+type(FilterBlockStatement, 'FilterBlockStatement');
+alias(FilterBlockStatement, 'Statement', 'Block');
+visitor(FilterBlockStatement, 'filterExpression', 'body');
+
+export class FlushStatement extends Node {
+    constructor() {
+        super();
+    }
+}
+type(FlushStatement, 'FlushStatement');
+alias(FlushStatement, 'Statement');
+
+export class ForStatement extends Node {
+    constructor(
+        keyTarget?: Identifier = null,
+        valueTarget?: Identifier = null,
+        sequence?: Node = null,
+        condition?: Node = null,
+        body?: Node = null,
+        otherwise?: Node = null
+    ) {
+        super();
+        this.keyTarget = keyTarget;
+        this.valueTarget = valueTarget;
+        this.sequence = sequence;
+        this.condition = condition;
+        this.body = body;
+        this.otherwise = otherwise;
+    }
+}
+type(ForStatement, 'ForStatement');
+alias(ForStatement, 'Statement', 'Scope', 'Loop');
+visitor(
+    ForStatement,
+    'keyTarget',
+    'valueTarget',
+    'sequence',
+    'condition',
+    'body',
+    'otherwise'
+);
+
+export class ImportDeclaration extends Node {
+    constructor(key: Node, alias: Identifier) {
+        super();
+        this.key = key;
+        this.alias = alias;
+    }
+}
+type(ImportDeclaration, 'ImportDeclaration');
+alias(ImportDeclaration, 'VariableDeclaration');
+visitor(ImportDeclaration, 'key', 'value');
+
+export class FromStatement extends Node {
+    constructor(source: Node, imports: Array<ImportDeclaration>) {
+        super();
+        this.source = source;
+        this.imports = imports;
+    }
+}
+type(FromStatement, 'FromStatement');
+alias(FromStatement, 'Statement');
+visitor(FromStatement, 'source', 'imports');
+
+export class IfStatement extends Node {
+    constructor(test: Node, consequent?: Node = null, alternate?: Node = null) {
+        super();
+        this.test = test;
+        this.consequent = consequent;
+        this.alternate = alternate;
+    }
+}
+type(IfStatement, 'IfStatement');
+alias(IfStatement, 'Statement', 'Conditional');
+visitor(IfStatement, 'test', 'consequent', 'alternate');
+
+export class IncludeStatement extends Node {
+    constructor(source: Node) {
+        super();
+        this.source = source;
+        this.argument = null;
+        this.contextFree = false;
+        // when `true`, missing templates will be ignored
+        this.ignoreMissing = false;
+    }
+}
+type(IncludeStatement, 'IncludeStatement');
+alias(IncludeStatement, 'Statement', 'Include');
+visitor(IncludeStatement, 'source', 'argument');
+
+export class MacroDeclarationStatement extends Node {
+    constructor(name: Identifier, args: Array<Node>, body: SequenceExpression) {
+        super();
+        this.name = name;
+        this.arguments = args;
+        this.body = body;
+    }
+}
+type(MacroDeclarationStatement, 'MacroDeclarationStatement');
+alias(MacroDeclarationStatement, 'Statement', 'Scope', 'RootScope');
+visitor(MacroDeclarationStatement, 'name', 'arguments', 'body');
+
+export class VariableDeclarationStatement extends Node {
+    constructor(name: Identifier, value: Node) {
+        super();
+        this.name = name;
+        this.value = value;
+    }
+}
+type(VariableDeclarationStatement, 'VariableDeclarationStatement');
+alias(VariableDeclarationStatement, 'Statement');
+visitor(VariableDeclarationStatement, 'name', 'value');
+
+export class SetStatement extends Node {
+    constructor(assignments: Array<VariableDeclarationStatement>) {
+        super();
+        this.assignments = assignments;
+    }
+}
+type(SetStatement, 'SetStatement');
+alias(SetStatement, 'Statement', 'ContextMutation');
+visitor(SetStatement, 'assignments');
+
+export class SpacelessBlock extends Node {
+    constructor(body?: Node = null) {
+        super();
+        this.body = body;
+    }
+}
+type(SpacelessBlock, 'SpacelessBlock');
+alias(SpacelessBlock, 'Statement', 'Block');
+visitor(SpacelessBlock, 'body');
+
+export class AliasExpression extends Node {
+    constructor(name: Identifier, alias: Identifier) {
+        super();
+        this.name = name;
+        this.alias = alias;
+    }
+}
+type(AliasExpression, 'AliasExpression');
+alias(AliasExpression, 'Expression');
+visitor(AliasExpression, 'name', 'alias');
+
+export class UseStatement extends Node {
+    constructor(source: Node, aliases: Array<AliasExpression>) {
+        super();
+        this.source = source;
+        this.aliases = aliases;
+    }
+}
+type(UseStatement, 'UseStatement');
+alias(UseStatement, 'Statement', 'Include');
+visitor(UseStatement, 'source', 'aliases');
+
+export {
+    UnaryNotExpression,
+    UnaryNeqExpression,
+    UnaryPosExpression,
+    BinaryOrExpression,
+    BinaryAndExpression,
+    BitwiseOrExpression,
+    BitwiseXorExpression,
+    BitwiseAndExpression,
+    BinaryEqualsExpression,
+    BinaryNotEqualsExpression,
+    BinaryLessThanExpression,
+    BinaryGreaterThanExpression,
+    BinaryLessThanOrEqualExpression,
+    BinaryGreaterThanOrEqualExpression,
+    BinaryNotInExpression,
+    BinaryInExpression,
+    BinaryMatchesExpression,
+    BinaryStartsWithExpression,
+    BinaryEndsWithExpression,
+    BinaryRangeExpression,
+    BinaryAddExpression,
+    BinaryMulExpression,
+    BinaryDivExpression,
+    BinaryFloorDivExpression,
+    BinaryModExpression,
+    BinaryPowerExpression,
+    BinaryNullCoalesceExpression,
+    TestEvenExpression,
+    TestOddExpression,
+    TestDefinedExpression,
+    TestSameAsExpression,
+    TestNullExpression,
+    TestDivisibleByExpression,
+    TestConstantExpression,
+    TestEmptyExpression,
+    TestIterableExpression,
+} from './operators';

--- a/src/melody/melody-extension-core/visitors/filters.js
+++ b/src/melody/melody-extension-core/visitors/filters.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as t from 'babel-types';
+import template from 'babel-template';
+
+// use default value if var is null, undefined or an empty string
+// but use var if value is 0, false, an empty array or an empty object
+const defaultFilter = template("VAR != null && VAR !== '' ? VAR : DEFAULT");
+
+export default {
+    capitalize: 'lodash',
+    first: 'lodash',
+    last: 'lodash',
+    keys: 'lodash',
+    default(path) {
+        // babel-template transforms it to an expression statement
+        // but we really need an expression here, so unwrap it
+        path.replaceWithJS(
+            defaultFilter({
+                VAR: path.node.target,
+                DEFAULT: path.node.arguments[0] || t.stringLiteral(''),
+            }).expression
+        );
+    },
+    abs(path) {
+        // todo throw error if arguments exist
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(t.identifier('Math'), t.identifier('abs')),
+                [path.node.target]
+            )
+        );
+    },
+    join(path) {
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(path.node.target, t.identifier('join')),
+                path.node.arguments
+            )
+        );
+    },
+    json_encode(path) {
+        // todo: handle arguments
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(
+                    t.identifier('JSON'),
+                    t.identifier('stringify')
+                ),
+                [path.node.target]
+            )
+        );
+    },
+    length(path) {
+        path.replaceWithJS(
+            t.memberExpression(path.node.target, t.identifier('length'))
+        );
+    },
+    lower(path) {
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(
+                    path.node.target,
+                    t.identifier('toLowerCase')
+                ),
+                []
+            )
+        );
+    },
+    upper(path) {
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(
+                    path.node.target,
+                    t.identifier('toUpperCase')
+                ),
+                []
+            )
+        );
+    },
+    slice(path) {
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(path.node.target, t.identifier('slice')),
+                path.node.arguments
+            )
+        );
+    },
+    sort(path) {
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(path.node.target, t.identifier('sort')),
+                path.node.arguments
+            )
+        );
+    },
+    split(path) {
+        path.replaceWithJS(
+            t.callExpression(
+                t.memberExpression(path.node.target, t.identifier('split')),
+                path.node.arguments
+            )
+        );
+    },
+    convert_encoding(path) {
+        // encoding conversion is not supported
+        path.replaceWith(path.node.target);
+    },
+    date_modify(path) {
+        path.replaceWithJS(
+            t.callExpression(
+                t.identifier(
+                    path.state.addImportFrom('melody-runtime', 'strtotime')
+                ),
+                [path.node.arguments[0], path.node.target]
+            )
+        );
+    },
+    date(path) {
+        // Not really happy about this since moment.js could well be incompatible with
+        // the default twig behaviour
+        // might need to switch to an actual strftime implementation
+        path.replaceWithJS(
+            t.callExpression(
+                t.callExpression(
+                    t.identifier(path.state.addDefaultImportFrom('moment')),
+                    [path.node.target]
+                ),
+                [path.node.arguments[0]]
+            )
+        );
+    },
+};

--- a/src/melody/melody-extension-core/visitors/for.js
+++ b/src/melody/melody-extension-core/visitors/for.js
@@ -1,0 +1,392 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { traverse } from 'melody-traverse';
+import * as t from 'babel-types';
+import babelTemplate from 'babel-template';
+
+// @param template
+// @returns function
+//     @param context context bindings
+//     @returns {exprStmt, initDecl, forStmt}
+const template = tpl => {
+    return ctx => parseExpr(babelTemplate(tpl)(ctx));
+};
+
+const forWithContext = template(`
+{
+let SEQUENCE = SOURCE,
+KEY_TARGET = 0,
+LENGTH = SEQUENCE.length,
+SUB_CONTEXT = CREATE_SUB_CONTEXT(CONTEXT, {
+    VALUE_TARGET: SEQUENCE[0],
+    loop: {
+        index: 1,
+        index0: 0,
+        length: LENGTH,
+        revindex: LENGTH,
+        revindex0: LENGTH - 1,
+        first: true,
+        last: 1 === LENGTH
+    }
+});
+for (;
+    KEY_TARGET < LENGTH;
+    KEY_TARGET++
+) {
+    SUB_CONTEXT.loop.index0++;
+    SUB_CONTEXT.loop.index++;
+    SUB_CONTEXT.loop.revindex--;
+    SUB_CONTEXT.loop.revindex0--;
+    SUB_CONTEXT.loop.first = false;
+    SUB_CONTEXT.loop.last = SUB_CONTEXT.loop.revindex === 0;
+    SUB_CONTEXT.VALUE_TARGET = _sequence[KEY_TARGET + 1];
+}
+}
+`);
+
+const basicFor = template(`
+{
+let SEQUENCE = SOURCE,
+KEY_TARGET = 0,
+LENGTH = SEQUENCE.length,
+VALUE_TARGET = SEQUENCE[0];
+for (;
+    KEY_TARGET < LENGTH;
+    KEY_TARGET++,
+    VALUE_TARGET = SEQUENCE[_index]
+) {
+}
+}
+`);
+
+const localFor = template(`
+{
+let SEQUENCE = SOURCE,
+KEY_TARGET = 0,
+LENGTH = SEQUENCE.length,
+VALUE_TARGET = SEQUENCE[0],
+INDEX_BY_1 = 1,
+REVERSE_INDEX_BY_1 = LENGTH,
+REVERSE_INDEX = LENGTH - 1,
+FIRST = true,
+LAST = 1 === LENGTH;
+for (;
+    KEY_TARGET < LENGTH;
+    KEY_TARGET++,
+    VALUE_TARGET = SEQUENCE[_index]
+) {
+    INDEX_BY_1++;
+    REVERSE_INDEX_BY_1--;
+    REVERSE_INDEX--;
+    FIRST = false;
+    LAST = REVERSE_INDEX === 0;
+}
+}
+`);
+
+// returns an object that has the whole expression, init declarations, for loop
+// statement in respective properties.
+function parseExpr(exprStmt) {
+    return {
+        exprStmt: exprStmt,
+        initDecl: exprStmt.body[0].declarations,
+        forStmt: exprStmt.body[1],
+    };
+}
+
+export default {
+    analyse: {
+        ForStatement: {
+            enter(path) {
+                const forStmt = path.node,
+                    scope = path.scope;
+                if (forStmt.keyTarget) {
+                    scope.registerBinding(
+                        forStmt.keyTarget.name,
+                        path.get('keyTarget'),
+                        'var'
+                    );
+                }
+                if (forStmt.valueTarget) {
+                    scope.registerBinding(
+                        forStmt.valueTarget.name,
+                        path.get('valueTarget'),
+                        'var'
+                    );
+                }
+                scope.registerBinding('loop', path, 'var');
+            },
+            exit(path) {
+                const sequenceName = path.scope.generateUid('sequence'),
+                    lenName = path.scope.generateUid('length');
+                path.scope.registerBinding(sequenceName, path, 'var');
+                path.scope.registerBinding(lenName, path, 'var');
+                let iName;
+                if (path.node.keyTarget) {
+                    iName = path.node.keyTarget.name;
+                } else {
+                    iName = path.scope.generateUid('index0');
+                    path.scope.registerBinding(iName, path, 'var');
+                }
+                path.setData('forStatement.variableLookup', {
+                    sequenceName,
+                    lenName,
+                    iName,
+                });
+
+                if (path.scope.escapesContext) {
+                    const contextName = path.scope.generateUid('context');
+                    path.scope.registerBinding(contextName, path, 'const');
+                    path.scope.contextName = contextName;
+                    path.scope.getBinding('loop').kind = 'context';
+                    if (path.node.valueTarget) {
+                        path.scope.getBinding(path.node.valueTarget.name).kind =
+                            'context';
+                    }
+                } else if (path.scope.getBinding('loop').references) {
+                    const indexName = path.scope.generateUid('index');
+                    path.scope.registerBinding(indexName, path, 'var');
+                    const revindexName = path.scope.generateUid('revindex');
+                    path.scope.registerBinding(revindexName, path, 'var');
+                    const revindex0Name = path.scope.generateUid('revindex0');
+                    path.scope.registerBinding(revindex0Name, path, 'var');
+                    const firstName = path.scope.generateUid('first');
+                    path.scope.registerBinding(firstName, path, 'var');
+                    const lastName = path.scope.generateUid('last');
+                    path.scope.registerBinding(lastName, path, 'var');
+
+                    const lookupTable = {
+                        index: indexName,
+                        index0: iName,
+                        length: lenName,
+                        revindex: revindexName,
+                        revindex0: revindex0Name,
+                        first: firstName,
+                        last: lastName,
+                    };
+                    path.setData('forStatement.loopLookup', lookupTable);
+
+                    const loopBinding = path.scope.getBinding('loop');
+                    for (const loopPath of loopBinding.referencePaths) {
+                        const memExpr = loopPath.parentPath;
+
+                        if (memExpr.is('MemberExpression')) {
+                            const typeName = memExpr.node.property.name;
+                            if (typeName === 'index0') {
+                                memExpr.replaceWithJS({
+                                    type: 'BinaryExpression',
+                                    operator: '-',
+                                    left: {
+                                        type: 'Identifier',
+                                        name: indexName,
+                                    },
+                                    right: { type: 'NumericLiteral', value: 1 },
+                                    extra: {
+                                        parenthesized: true,
+                                    },
+                                });
+                            } else {
+                                memExpr.replaceWithJS({
+                                    type: 'Identifier',
+                                    name: lookupTable[typeName],
+                                });
+                            }
+                        }
+                    }
+                }
+            },
+        },
+    },
+    convert: {
+        ForStatement: {
+            enter(path) {
+                if (path.scope.escapesContext) {
+                    var parentContextName = path.scope.parent.contextName;
+                    if (path.node.otherwise) {
+                        const alternate = path.get('otherwise');
+                        if (alternate.is('Scope')) {
+                            alternate.scope.contextName = parentContextName;
+                        }
+                    }
+
+                    const sequence = path.get('sequence');
+
+                    if (sequence.is('Identifier')) {
+                        sequence.setData(
+                            'Identifier.contextName',
+                            parentContextName
+                        );
+                    } else {
+                        traverse(path.node.sequence, {
+                            Identifier(id) {
+                                id.setData(
+                                    'Identifier.contextName',
+                                    parentContextName
+                                );
+                            },
+                        });
+                    }
+                }
+            },
+            exit(path) {
+                const node = path.node;
+                const { sequenceName, lenName, iName } = path.getData(
+                    'forStatement.variableLookup'
+                );
+                let expr;
+                if (path.scope.escapesContext) {
+                    const contextName = path.scope.contextName;
+                    expr = forWithContext({
+                        CONTEXT: t.identifier(path.scope.parent.contextName),
+                        SUB_CONTEXT: t.identifier(contextName),
+                        CREATE_SUB_CONTEXT: t.identifier(
+                            this.addImportFrom(
+                                'melody-runtime',
+                                'createSubContext'
+                            )
+                        ),
+                        KEY_TARGET: t.identifier(iName),
+                        SOURCE: path.get('sequence').node,
+                        SEQUENCE: t.identifier(sequenceName),
+                        LENGTH: t.identifier(lenName),
+                        VALUE_TARGET: node.valueTarget,
+                    });
+                    if (node.keyTarget) {
+                        expr.forStmt.body.body.push({
+                            type: 'ExpressionStatement',
+                            expression: {
+                                type: 'AssignmentExpression',
+                                operator: '=',
+                                left: {
+                                    type: 'MemberExpression',
+                                    object: {
+                                        type: 'Identifier',
+                                        name: contextName,
+                                    },
+                                    property: {
+                                        type: 'Identifier',
+                                        name: node.keyTarget.name,
+                                    },
+                                    computed: false,
+                                },
+                                right: {
+                                    type: 'Identifier',
+                                    name: iName,
+                                },
+                            },
+                        });
+                        expr.initDecl[
+                            expr.initDecl.length - 1
+                        ].init.arguments[1].properties.push({
+                            type: 'ObjectProperty',
+                            method: false,
+                            shorthand: false,
+                            computed: false,
+                            key: {
+                                type: 'Identifier',
+                                name: node.keyTarget.name,
+                            },
+                            value: {
+                                type: 'Identifier',
+                                name: iName,
+                            },
+                        });
+                    }
+                } else if (path.scope.getBinding('loop').references) {
+                    const {
+                        index: indexName,
+                        revindex: revindexName,
+                        revindex0: revindex0Name,
+                        first: firstName,
+                        last: lastName,
+                    } = path.getData('forStatement.loopLookup');
+
+                    expr = localFor({
+                        KEY_TARGET: t.identifier(iName),
+                        SOURCE: path.get('sequence').node,
+                        SEQUENCE: t.identifier(sequenceName),
+                        LENGTH: t.identifier(lenName),
+                        VALUE_TARGET: node.valueTarget,
+                        INDEX_BY_1: t.identifier(indexName),
+                        REVERSE_INDEX: t.identifier(revindex0Name),
+                        REVERSE_INDEX_BY_1: t.identifier(revindexName),
+                        FIRST: t.identifier(firstName),
+                        LAST: t.identifier(lastName),
+                    });
+                } else {
+                    expr = basicFor({
+                        SEQUENCE: t.identifier(sequenceName),
+                        SOURCE: path.get('sequence').node,
+                        KEY_TARGET: t.identifier(iName),
+                        LENGTH: t.identifier(lenName),
+                        VALUE_TARGET: node.valueTarget,
+                    });
+                }
+
+                expr.forStmt.body.body.unshift(...path.get('body').node.body);
+
+                let uniteratedName;
+                if (node.otherwise) {
+                    uniteratedName = path.scope.generateUid('uniterated');
+                    path.scope.parent.registerBinding(
+                        uniteratedName,
+                        path,
+                        'var'
+                    );
+                    expr.forStmt.body.body.push(
+                        t.expressionStatement(
+                            t.assignmentExpression(
+                                '=',
+                                t.identifier(uniteratedName),
+                                t.booleanLiteral(false)
+                            )
+                        )
+                    );
+                }
+
+                if (node.condition) {
+                    expr.forStmt.body = t.blockStatement([
+                        {
+                            type: 'IfStatement',
+                            test: node.condition,
+                            consequent: t.blockStatement(
+                                expr.forStmt.body.body
+                            ),
+                        },
+                    ]);
+                }
+
+                if (uniteratedName) {
+                    path.replaceWithMultipleJS(
+                        t.variableDeclaration('let', [
+                            t.variableDeclarator(
+                                t.identifier(uniteratedName),
+                                t.booleanLiteral(true)
+                            ),
+                        ]),
+                        expr.exprStmt,
+                        t.ifStatement(
+                            t.identifier(uniteratedName),
+                            node.otherwise
+                        )
+                    );
+                } else {
+                    path.replaceWithJS(expr.exprStmt);
+                }
+            },
+        },
+    },
+};

--- a/src/melody/melody-extension-core/visitors/functions.js
+++ b/src/melody/melody-extension-core/visitors/functions.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as t from 'babel-types';
+
+function addOne(expr) {
+    return t.binaryExpression('+', expr, t.numericLiteral(1));
+}
+
+export default {
+    range(path) {
+        const args = path.node.arguments;
+        const callArgs = [];
+        if (args.length === 1) {
+            callArgs.push(addOne(args[0]));
+        } else if (args.length === 3) {
+            callArgs.push(args[0]);
+            callArgs.push(addOne(args[1]));
+            callArgs.push(args[2]);
+        } else if (args.length === 2) {
+            callArgs.push(args[0], addOne(args[1]));
+        } else {
+            path.state.error(
+                'Invalid range call',
+                path.node.pos,
+                `The range function accepts 1 to 3 arguments but you have specified ${
+                    args.length
+                } arguments instead.`
+            );
+        }
+
+        path.replaceWithJS(
+            t.callExpression(
+                t.identifier(path.state.addImportFrom('lodash', 'range')),
+                callArgs
+            )
+        );
+    },
+    // range: 'lodash',
+    dump(path) {
+        if (!path.parentPath.is('PrintExpressionStatement')) {
+            path.state.error(
+                'dump must be used in a lone expression',
+                path.node.pos,
+                'The dump function does not have a return value. Thus it must be used as the only expression.'
+            );
+        }
+        path.parentPath.replaceWithJS(
+            t.expressionStatement(
+                t.callExpression(
+                    t.memberExpression(
+                        t.identifier('console'),
+                        t.identifier('log')
+                    ),
+                    path.node.arguments
+                )
+            )
+        );
+    },
+    include(path) {
+        if (!path.parentPath.is('PrintExpressionStatement')) {
+            path.state.error({
+                title: 'Include function does not return value',
+                pos: path.node.loc.start,
+                advice: `The include function currently does not return a value.
+                Thus you must use it like a regular include tag.`,
+            });
+        }
+        const includeName = path.scope.generateUid('include');
+        const importDecl = t.importDeclaration(
+            [t.importDefaultSpecifier(t.identifier(includeName))],
+            path.node.arguments[0]
+        );
+        path.state.program.body.splice(0, 0, importDecl);
+        path.scope.registerBinding(includeName);
+
+        const argument = path.node.arguments[1];
+
+        const includeCall = t.expressionStatement(
+            t.callExpression(
+                t.memberExpression(
+                    t.identifier(includeName),
+                    t.identifier('render')
+                ),
+                argument ? [argument] : []
+            )
+        );
+        path.replaceWithJS(includeCall);
+    },
+};

--- a/src/melody/melody-extension-core/visitors/tests.js
+++ b/src/melody/melody-extension-core/visitors/tests.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as t from 'babel-types';
+
+export default {
+    convert: {
+        TestEvenExpression: {
+            exit(path) {
+                const expr = t.unaryExpression(
+                    '!',
+                    t.binaryExpression(
+                        '%',
+                        path.get('expression').node,
+                        t.numericLiteral(2)
+                    )
+                );
+                expr.extra = { parenthesizedArgument: true };
+                path.replaceWithJS(expr);
+            },
+        },
+        TestOddExpression: {
+            exit(path) {
+                const expr = t.unaryExpression(
+                    '!',
+                    t.unaryExpression(
+                        '!',
+                        t.binaryExpression(
+                            '%',
+                            path.get('expression').node,
+                            t.numericLiteral(2)
+                        )
+                    )
+                );
+                expr.extra = { parenthesizedArgument: true };
+                path.replaceWithJS(expr);
+            },
+        },
+        TestDefinedExpression: {
+            exit(path) {
+                path.replaceWithJS(
+                    t.binaryExpression(
+                        '!==',
+                        t.unaryExpression(
+                            'typeof',
+                            path.get('expression').node
+                        ),
+                        t.stringLiteral('undefined')
+                    )
+                );
+            },
+        },
+        TestEmptyExpression: {
+            exit(path) {
+                path.replaceWithJS(
+                    t.callExpression(
+                        t.identifier(
+                            this.addImportFrom('melody-runtime', 'isEmpty')
+                        ),
+                        [path.get('expression').node]
+                    )
+                );
+            },
+        },
+        TestSameAsExpression: {
+            exit(path) {
+                path.replaceWithJS(
+                    t.binaryExpression(
+                        '===',
+                        path.get('expression').node,
+                        path.get('arguments')[0].node
+                    )
+                );
+            },
+        },
+        TestNullExpression: {
+            exit(path) {
+                path.replaceWithJS(
+                    t.binaryExpression(
+                        '===',
+                        path.get('expression').node,
+                        t.nullLiteral()
+                    )
+                );
+            },
+        },
+        TestDivisibleByExpression: {
+            exit(path) {
+                path.replaceWithJS(
+                    t.unaryExpression(
+                        '!',
+                        t.binaryExpression(
+                            '%',
+                            path.get('expression').node,
+                            path.node.arguments[0]
+                        )
+                    )
+                );
+            },
+        },
+        TestIterableExpression: {
+            exit(path) {
+                path.replaceWithJS(
+                    t.callExpression(
+                        t.memberExpression(
+                            t.identifier('Array'),
+                            t.identifier('isArray')
+                        ),
+                        [path.node.expression]
+                    )
+                );
+            },
+        },
+    },
+};

--- a/src/melody/melody-parser/Associativity.js
+++ b/src/melody/melody-parser/Associativity.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export var LEFT = Symbol();
+export var RIGHT = Symbol();

--- a/src/melody/melody-parser/CharStream.js
+++ b/src/melody/melody-parser/CharStream.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const EOF = Symbol();
+
+export class CharStream {
+    constructor(input) {
+        this.input = String(input);
+        this.length = this.input.length;
+        this.index = 0;
+        this.position = { line: 1, column: 0 };
+    }
+
+    get source() {
+        return this.input;
+    }
+
+    reset() {
+        this.rewind({ line: 1, column: 0, index: 0 });
+    }
+
+    mark() {
+        let { line, column } = this.position,
+            index = this.index;
+        return { line, column, index };
+    }
+
+    rewind(marker) {
+        this.position.line = marker.line;
+        this.position.column = marker.column;
+        this.index = marker.index;
+    }
+
+    la(offset) {
+        var index = this.index + offset;
+        return index < this.length ? this.input.charAt(index) : EOF;
+    }
+
+    lac(offset) {
+        var index = this.index + offset;
+        return index < this.length ? this.input.charCodeAt(index) : EOF;
+    }
+
+    next() {
+        if (this.index === this.length) {
+            return EOF;
+        }
+        var ch = this.input.charAt(this.index);
+        this.index++;
+        this.position.column++;
+        if (ch === '\n') {
+            this.position.line += 1;
+            this.position.column = 0;
+        }
+        return ch;
+    }
+
+    match(str) {
+        const start = this.mark();
+        for (let i = 0, len = str.length; i < len; i++) {
+            const ch = this.next();
+            if (ch !== str.charAt(i) || ch === EOF) {
+                this.rewind(start);
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/melody/melody-parser/GenericMultiTagParser.js
+++ b/src/melody/melody-parser/GenericMultiTagParser.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { setStartFromToken, setEndFromToken } from './util';
+import { GenericTagParser } from './GenericTagParser';
+import * as Types from './TokenTypes';
+
+const tagMatchesOneOf = (tokenStream, tagNames) => {
+    for (let i = 0; i < tagNames.length; i++) {
+        if (tokenStream.test(Types.SYMBOL, tagNames[i])) {
+            return true;
+        }
+    }
+    return false;
+};
+
+export const createMultiTagParser = (tagName, subTags = []) => ({
+    name: 'genericTwigMultiTag',
+    parse(parser, token) {
+        const tokens = parser.tokens,
+            tagStartToken = tokens.la(-1);
+
+        if (subTags.length === 0) {
+            subTags.push('end' + tagName);
+        }
+
+        const twigTag = GenericTagParser.parse(parser, token);
+        let currentTagName = tagName;
+        const endTagName = subTags[subTags.length - 1];
+
+        while (currentTagName !== endTagName) {
+            // Parse next section
+            twigTag.sections.push(
+                parser.parse((tokenText, token, tokens) => {
+                    const hasReachedNextTag =
+                        token.type === Types.TAG_START &&
+                        tagMatchesOneOf(tokens, subTags);
+                    return hasReachedNextTag;
+                })
+            );
+            tokens.next(); // Get past "{%"
+
+            // Parse next tag
+            const childTag = GenericTagParser.parse(parser);
+            twigTag.sections.push(childTag);
+            currentTagName = childTag.tagName;
+        }
+
+        setStartFromToken(twigTag, tagStartToken);
+        setEndFromToken(twigTag, tokens.la(0));
+
+        return twigTag;
+    },
+});

--- a/src/melody/melody-parser/GenericTagParser.js
+++ b/src/melody/melody-parser/GenericTagParser.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { hasTagStartTokenTrimLeft, hasTagEndTokenTrimRight } from './util';
+import * as Types from './TokenTypes';
+import * as n from 'melody-types';
+
+export const GenericTagParser = {
+    name: 'genericTwigTag',
+    parse(parser) {
+        const tokens = parser.tokens,
+            tagStartToken = tokens.la(-2);
+        let currentToken;
+
+        const twigTag = new n.GenericTwigTag(tokens.la(-1).text);
+        while ((currentToken = tokens.la(0))) {
+            if (currentToken.type === Types.TAG_END) {
+                break;
+            } else {
+                try {
+                    twigTag.parts.push(parser.matchExpression());
+                } catch (e) {
+                    if (e.errorType === 'UNEXPECTED_TOKEN') {
+                        twigTag.parts.push(
+                            new n.GenericToken(e.tokenType, e.tokenText)
+                        );
+                        tokens.next();
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+        }
+        tokens.expect(Types.TAG_END);
+
+        twigTag.trimLeft = hasTagStartTokenTrimLeft(tagStartToken);
+        twigTag.trimRight = hasTagEndTokenTrimRight(currentToken);
+
+        return twigTag;
+    },
+};

--- a/src/melody/melody-parser/Lexer.js
+++ b/src/melody/melody-parser/Lexer.js
@@ -1,0 +1,670 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as TokenTypes from './TokenTypes';
+import { EOF } from './CharStream';
+
+const State = {
+    TEXT: 'TEXT',
+    EXPRESSION: 'EXPRESSION',
+    TAG: 'TAG',
+    INTERPOLATION: 'INTERPOLATION',
+    STRING_SINGLE: 'STRING_SINGLE',
+    STRING_DOUBLE: 'STRING_DOUBLE',
+    ELEMENT: 'ELEMENT',
+    ATTRIBUTE_VALUE: 'ATTRIBUTE_VALUE',
+    DECLARATION: 'DECLARATION',
+};
+
+const STATE = Symbol(),
+    OPERATORS = Symbol(),
+    STRING_START = Symbol();
+
+const CHAR_TO_TOKEN = {
+    '[': TokenTypes.LBRACE,
+    ']': TokenTypes.RBRACE,
+    '(': TokenTypes.LPAREN,
+    ')': TokenTypes.RPAREN,
+    '{': TokenTypes.LBRACKET,
+    '}': TokenTypes.RBRACKET,
+    ':': TokenTypes.COLON,
+    '.': TokenTypes.DOT,
+    '|': TokenTypes.PIPE,
+    ',': TokenTypes.COMMA,
+    '?': TokenTypes.QUESTION_MARK,
+    '=': TokenTypes.ASSIGNMENT,
+    //'<': TokenTypes.ELEMENT_START,
+    //'>': TokenTypes.ELEMENT_END,
+    '/': TokenTypes.SLASH,
+};
+
+export default class Lexer {
+    constructor(input, { preserveSourceLiterally = false } = {}) {
+        this.input = input;
+        this[STATE] = [State.TEXT];
+        this[OPERATORS] = [];
+        this[STRING_START] = null;
+        this.options = {
+            preserveSourceLiterally:
+                preserveSourceLiterally === true ? true : false,
+        };
+    }
+
+    applyExtension(ext) {
+        if (ext.unaryOperators) {
+            this.addOperators(...ext.unaryOperators.map(op => op.text));
+        }
+        if (ext.binaryOperators) {
+            this.addOperators(...ext.binaryOperators.map(op => op.text));
+        }
+    }
+
+    reset() {
+        this.input.reset();
+        this[STATE] = [State.TEXT];
+    }
+
+    get source() {
+        return this.input.source;
+    }
+
+    addOperators(...ops) {
+        this[OPERATORS].push(...ops);
+        this[OPERATORS].sort((a, b) => (a.length > b.length ? -1 : 1));
+    }
+
+    get state() {
+        return this[STATE][this[STATE].length - 1];
+    }
+
+    pushState(state) {
+        this[STATE].push(state);
+    }
+
+    popState() {
+        this[STATE].length--;
+    }
+
+    createToken(type, pos) {
+        let input = this.input,
+            endPos = input.mark(),
+            end = endPos.index;
+        return {
+            type,
+            pos,
+            endPos,
+            end,
+            length: end - pos.index,
+            source: input.input,
+            text: input.input.substr(pos.index, end - pos.index),
+            toString: function() {
+                return this.text;
+            },
+        };
+    }
+
+    next() {
+        let input = this.input,
+            pos,
+            c;
+        while ((c = input.la(0)) !== EOF) {
+            pos = input.mark();
+            if (
+                this.state !== State.TEXT &&
+                this.state !== State.STRING_DOUBLE &&
+                this.state !== State.STRING_SINGLE &&
+                this.state !== State.ATTRIBUTE_VALUE &&
+                isWhitespace(c)
+            ) {
+                input.next();
+                while ((c = input.la(0)) !== EOF && isWhitespace(c)) {
+                    input.next();
+                }
+                return this.createToken(TokenTypes.WHITESPACE, pos);
+            }
+            if (c === '{' && input.la(1) === '#') {
+                input.next();
+                input.next();
+                if (input.la(0) === '-') {
+                    input.next();
+                }
+                while ((c = input.la(0)) !== EOF) {
+                    if (
+                        (c === '#' && input.la(1) === '}') ||
+                        (c === '-' &&
+                            input.la(1) === '#' &&
+                            input.la(2) === '}')
+                    ) {
+                        if (c === '-') {
+                            input.next();
+                        }
+                        input.next();
+                        input.next();
+                        return this.createToken(TokenTypes.COMMENT, pos);
+                    }
+                    input.next();
+                }
+            }
+            if (this.state === State.TEXT) {
+                let entityToken;
+                if (c === '<') {
+                    if (
+                        input.la(1) === '{' ||
+                        isAlpha(input.lac(1)) ||
+                        input.la(1) === '/'
+                    ) {
+                        input.next();
+                        this.pushState(State.ELEMENT);
+                        return this.createToken(TokenTypes.ELEMENT_START, pos);
+                    } else if (
+                        input.la(1) === '!' &&
+                        input.la(2) === '-' &&
+                        input.la(3) === '-'
+                    ) {
+                        // match HTML comment
+                        input.next(); // <
+                        input.next(); // !
+                        input.next(); // -
+                        input.next(); // -
+                        while ((c = input.la(0)) !== EOF) {
+                            if (c === '-' && input.la(1) === '-') {
+                                input.next();
+                                input.next();
+                                if (!(c = input.next()) === '>') {
+                                    this.error(
+                                        'Unexpected end for HTML comment',
+                                        input.mark(),
+                                        `Expected comment to end with '>' but found '${c}' instead.`
+                                    );
+                                }
+                                break;
+                            }
+                            input.next();
+                        }
+                        return this.createToken(TokenTypes.HTML_COMMENT, pos);
+                    } else if (
+                        input.la(1) === '!' &&
+                        (isAlpha(input.lac(2)) || isWhitespace(input.la(2)))
+                    ) {
+                        input.next();
+                        input.next();
+                        this.pushState(State.DECLARATION);
+                        return this.createToken(
+                            TokenTypes.DECLARATION_START,
+                            pos
+                        );
+                    } else {
+                        return this.matchText(pos);
+                    }
+                } else if (c === '{') {
+                    return this.matchExpressionToken(pos);
+                } else if (c === '&' && (entityToken = this.matchEntity(pos))) {
+                    return entityToken;
+                } else {
+                    return this.matchText(pos);
+                }
+            } else if (this.state === State.EXPRESSION) {
+                if (
+                    (c === '}' && input.la(1) === '}') ||
+                    (c === '-' && input.la(1) === '}' && input.la(2) === '}')
+                ) {
+                    if (c === '-') {
+                        input.next();
+                    }
+                    input.next();
+                    input.next();
+                    this.popState();
+                    return this.createToken(TokenTypes.EXPRESSION_END, pos);
+                }
+                return this.matchExpression(pos);
+            } else if (this.state === State.TAG) {
+                if (
+                    (c === '%' && input.la(1) === '}') ||
+                    (c === '-' && input.la(1) === '%' && input.la(2) === '}')
+                ) {
+                    if (c === '-') {
+                        input.next();
+                    }
+                    input.next();
+                    input.next();
+                    this.popState();
+                    return this.createToken(TokenTypes.TAG_END, pos);
+                }
+                return this.matchExpression(pos);
+            } else if (
+                this.state === State.STRING_SINGLE ||
+                this.state === State.STRING_DOUBLE
+            ) {
+                return this.matchString(pos, true);
+            } else if (this.state === State.INTERPOLATION) {
+                if (c === '}') {
+                    input.next();
+                    this.popState(); // pop interpolation
+                    return this.createToken(TokenTypes.INTERPOLATION_END, pos);
+                }
+                return this.matchExpression(pos);
+            } else if (this.state === State.ELEMENT) {
+                switch (c) {
+                    case '/':
+                        input.next();
+                        return this.createToken(TokenTypes.SLASH, pos);
+                    case '{':
+                        return this.matchExpressionToken(pos);
+                    case '>':
+                        input.next();
+                        this.popState();
+                        return this.createToken(TokenTypes.ELEMENT_END, pos);
+                    case '"':
+                        input.next();
+                        this.pushState(State.ATTRIBUTE_VALUE);
+                        return this.createToken(TokenTypes.STRING_START, pos);
+                    case '=':
+                        input.next();
+                        return this.createToken(TokenTypes.ASSIGNMENT, pos);
+                    default:
+                        return this.matchSymbol(pos);
+                }
+            } else if (this.state === State.ATTRIBUTE_VALUE) {
+                if (c === '"') {
+                    input.next();
+                    this.popState();
+                    return this.createToken(TokenTypes.STRING_END, pos);
+                } else {
+                    return this.matchAttributeValue(pos);
+                }
+            } else if (this.state === State.DECLARATION) {
+                switch (c) {
+                    case '>':
+                        input.next();
+                        this.popState();
+                        return this.createToken(TokenTypes.ELEMENT_END, pos);
+                    case '"':
+                        input.next();
+                        this.pushState(State.STRING_DOUBLE);
+                        return this.createToken(TokenTypes.STRING_START, pos);
+                    case '{':
+                        return this.matchExpressionToken(pos);
+                    default:
+                        return this.matchSymbol(pos);
+                }
+            } else {
+                return this.error(`Invalid state ${this.state}`, pos);
+            }
+        }
+        return TokenTypes.EOF_TOKEN;
+    }
+
+    matchExpressionToken(pos) {
+        const input = this.input;
+        switch (input.la(1)) {
+            case '{':
+                input.next();
+                input.next();
+                this.pushState(State.EXPRESSION);
+                if (input.la(0) === '-') {
+                    input.next();
+                }
+                return this.createToken(TokenTypes.EXPRESSION_START, pos);
+            case '%':
+                input.next();
+                input.next();
+                this.pushState(State.TAG);
+                if (input.la(0) === '-') {
+                    input.next();
+                }
+                return this.createToken(TokenTypes.TAG_START, pos);
+            case '#':
+                input.next();
+                input.next();
+                if (input.la(0) === '-') {
+                    input.next();
+                }
+                return this.matchComment(pos);
+            default:
+                return this.matchText(pos);
+        }
+    }
+
+    matchExpression(pos) {
+        let input = this.input,
+            c = input.la(0);
+        switch (c) {
+            case "'":
+                this.pushState(State.STRING_SINGLE);
+                input.next();
+                return this.createToken(TokenTypes.STRING_START, pos);
+            case '"':
+                this.pushState(State.STRING_DOUBLE);
+                input.next();
+                return this.createToken(TokenTypes.STRING_START, pos);
+            default: {
+                if (isDigit(input.lac(0))) {
+                    input.next();
+                    return this.matchNumber(pos);
+                }
+                if (
+                    (c === 't' && input.match('true')) ||
+                    (c === 'T' && input.match('TRUE'))
+                ) {
+                    return this.createToken(TokenTypes.TRUE, pos);
+                }
+                if (
+                    (c === 'f' && input.match('false')) ||
+                    (c === 'F' && input.match('FALSE'))
+                ) {
+                    return this.createToken(TokenTypes.FALSE, pos);
+                }
+                if (
+                    (c === 'n' &&
+                        (input.match('null') || input.match('none'))) ||
+                    (c === 'N' && (input.match('NULL') || input.match('NONE')))
+                ) {
+                    return this.createToken(TokenTypes.NULL, pos);
+                }
+                const {
+                    longestMatchingOperator,
+                    longestMatchEndPos,
+                } = this.findLongestMatchingOperator();
+                const cc = input.lac(0);
+                if (cc === 95 /* _ */ || isAlpha(cc) || isDigit(cc)) {
+                    // okay... this could be either a symbol or an operator
+                    input.next();
+                    const sym = this.matchSymbol(pos);
+                    if (sym.text.length <= longestMatchingOperator.length) {
+                        // the operator was longer so let's use that
+                        input.rewind(longestMatchEndPos);
+                        return this.createToken(TokenTypes.OPERATOR, pos);
+                    }
+                    // found a symbol
+                    return sym;
+                } else if (longestMatchingOperator) {
+                    input.rewind(longestMatchEndPos);
+                    return this.createToken(TokenTypes.OPERATOR, pos);
+                } else if (CHAR_TO_TOKEN.hasOwnProperty(c)) {
+                    input.next();
+                    return this.createToken(CHAR_TO_TOKEN[c], pos);
+                } else if (c === '\xa0') {
+                    return this.error(
+                        'Unsupported token: Non-breaking space',
+                        pos
+                    );
+                } else {
+                    return this.error(`Unknown token ${c}`, pos);
+                }
+            }
+        }
+    }
+
+    findLongestMatchingOperator() {
+        const input = this.input,
+            start = input.mark();
+        let longestMatchingOperator = '',
+            longestMatchEndPos = null;
+        for (let i = 0, ops = this[OPERATORS], len = ops.length; i < len; i++) {
+            const op = ops[i];
+            if (op.length > longestMatchingOperator.length && input.match(op)) {
+                const cc = input.lac(0);
+
+                // prevent mixing up operators with symbols (e.g. matching
+                // 'not in' in 'not invalid').
+                if (op.indexOf(' ') === -1 || !(isAlpha(cc) || isDigit(cc))) {
+                    longestMatchingOperator = op;
+                    longestMatchEndPos = input.mark();
+                }
+
+                input.rewind(start);
+            }
+        }
+        input.rewind(start);
+        return { longestMatchingOperator, longestMatchEndPos };
+    }
+
+    error(message, pos, advice = '') {
+        const errorToken = this.createToken(TokenTypes.ERROR, pos);
+        errorToken.message = message;
+        errorToken.advice = advice;
+        return errorToken;
+    }
+
+    matchEntity(pos) {
+        const input = this.input;
+        input.next(); // &
+        if (input.la(0) === '#') {
+            input.next(); // #
+            if (input.la(0) === 'x') {
+                // hexadecimal numeric character reference
+                input.next(); // x
+                let c = input.la(0);
+                while (
+                    ('a' <= c && c <= 'f') ||
+                    ('A' <= c && c <= 'F') ||
+                    isDigit(input.lac(0))
+                ) {
+                    input.next();
+                    c = input.la(0);
+                }
+                if (input.la(0) === ';') {
+                    input.next();
+                } else {
+                    input.rewind(pos);
+                    return null;
+                }
+            } else if (isDigit(input.lac(0))) {
+                // decimal numeric character reference
+                // consume decimal numbers
+                do {
+                    input.next();
+                } while (isDigit(input.lac(0)));
+                // check for final ";"
+                if (input.la(0) === ';') {
+                    input.next();
+                } else {
+                    input.rewind(pos);
+                    return null;
+                }
+            } else {
+                input.rewind(pos);
+                return null;
+            }
+        } else {
+            // match named character reference
+            while (isAlpha(input.lac(0))) {
+                input.next();
+            }
+            if (input.la(0) === ';') {
+                input.next();
+            } else {
+                input.rewind(pos);
+                return null;
+            }
+        }
+        return this.createToken(TokenTypes.ENTITY, pos);
+    }
+
+    matchSymbol(pos) {
+        let input = this.input,
+            inElement = this.state === State.ELEMENT,
+            c;
+        while (
+            (c = input.lac(0)) &&
+            (c === 95 ||
+                isAlpha(c) ||
+                isDigit(c) ||
+                (inElement && (c === 45 || c === 58)))
+        ) {
+            input.next();
+        }
+        var end = input.mark();
+        if (pos.index === end.index) {
+            return this.error(
+                'Expected an Identifier',
+                pos,
+                inElement
+                    ? `Expected a valid attribute name, but instead found "${input.la(
+                          0
+                      )}", which is not part of a valid attribute name.`
+                    : `Expected letter, digit or underscore but found ${input.la(
+                          0
+                      )} instead.`
+            );
+        }
+        return this.createToken(TokenTypes.SYMBOL, pos);
+    }
+
+    matchString(pos, allowInterpolation = true) {
+        const input = this.input,
+            start = this.state === State.STRING_SINGLE ? "'" : '"';
+        let c;
+        // string starts with an interpolation
+        if (allowInterpolation && input.la(0) === '#' && input.la(1) === '{') {
+            this.pushState(State.INTERPOLATION);
+            input.next();
+            input.next();
+            return this.createToken(TokenTypes.INTERPOLATION_START, pos);
+        }
+        if (input.la(0) === start) {
+            input.next();
+            this.popState();
+            return this.createToken(TokenTypes.STRING_END, pos);
+        }
+        while ((c = input.la(0)) !== start && c !== EOF) {
+            if (c === '\\' && input.la(1) === start) {
+                // escape sequence for string start
+                input.next();
+                input.next();
+            } else if (allowInterpolation && c === '#' && input.la(1) === '{') {
+                // found interpolation start, string part matched
+                // next iteration will match the interpolation
+                break;
+            } else {
+                input.next();
+            }
+        }
+        var result = this.createToken(TokenTypes.STRING, pos);
+        // Replace double backslash before escaped quotes
+        if (!this.options.preserveSourceLiterally) {
+            result.text = result.text.replace(
+                new RegExp('(?:\\\\)(' + start + ')', 'g'),
+                '$1'
+            );
+        }
+        return result;
+    }
+
+    matchAttributeValue(pos) {
+        let input = this.input,
+            start = this.state === State.STRING_SINGLE ? "'" : '"',
+            c;
+        if (input.la(0) === '{') {
+            return this.matchExpressionToken(pos);
+        }
+        while ((c = input.la(0)) !== start && c !== EOF) {
+            if (c === '\\' && input.la(1) === start) {
+                input.next();
+                input.next();
+            } else if (c === '{') {
+                // interpolation start
+                break;
+            } else if (c === start) {
+                break;
+            } else {
+                input.next();
+            }
+        }
+        var result = this.createToken(TokenTypes.STRING, pos);
+        // Replace double backslash before escaped quotes
+        if (!this.options.preserveSourceLiterally) {
+            result.text = result.text.replace(
+                new RegExp('(?:\\\\)(' + start + ')', 'g'),
+                '$1'
+            );
+        }
+        return result;
+    }
+
+    matchNumber(pos) {
+        let input = this.input,
+            c;
+        while ((c = input.lac(0)) !== EOF) {
+            if (!isDigit(c)) {
+                break;
+            }
+            input.next();
+        }
+        if (input.la(0) === '.' && isDigit(input.lac(1))) {
+            input.next();
+            while ((c = input.lac(0)) !== EOF) {
+                if (!isDigit(c)) {
+                    break;
+                }
+                input.next();
+            }
+        }
+        return this.createToken(TokenTypes.NUMBER, pos);
+    }
+
+    matchText(pos) {
+        let input = this.input,
+            c;
+        while ((c = input.la(0)) && c !== EOF) {
+            if (c === '{') {
+                const c2 = input.la(1);
+                if (c2 === '{' || c2 === '#' || c2 === '%') {
+                    break;
+                }
+            } else if (c === '<') {
+                const nextChar = input.la(1);
+                if (
+                    nextChar === '/' || // closing tag
+                    nextChar === '!' || // HTML comment
+                    isAlpha(input.lac(1)) // opening tag
+                ) {
+                    break;
+                } else if (input.la(1) === '{') {
+                    const c2 = input.la(1);
+                    if (c2 === '{' || c2 === '#' || c2 === '%') {
+                        break;
+                    }
+                }
+            }
+            input.next();
+        }
+        return this.createToken(TokenTypes.TEXT, pos);
+    }
+
+    matchComment(pos) {
+        let input = this.input,
+            c;
+        while ((c = input.next()) !== EOF) {
+            if (c === '#' && input.la(0) === '}') {
+                input.next(); // consume '}'
+                break;
+            }
+        }
+        return this.createToken(TokenTypes.COMMENT, pos);
+    }
+}
+
+function isWhitespace(c) {
+    return c === '\n' || c === ' ' || c === '\t';
+}
+
+function isAlpha(c) {
+    return (65 <= c && c <= 90) || (97 <= c && c <= 122);
+}
+
+function isDigit(c) {
+    return 48 <= c && c <= 57;
+}

--- a/src/melody/melody-parser/Parser.js
+++ b/src/melody/melody-parser/Parser.js
@@ -1,0 +1,950 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as n from 'melody-types';
+import * as Types from './TokenTypes';
+import { LEFT, RIGHT } from './Associativity';
+import {
+    setStartFromToken,
+    setEndFromToken,
+    setMarkFromToken,
+    copyStart,
+    copyEnd,
+    copyLoc,
+    createNode,
+} from './util';
+import { GenericTagParser } from './GenericTagParser';
+import { createMultiTagParser } from './GenericMultiTagParser';
+import { voidElements } from './elementInfo';
+import * as he from 'he';
+
+type UnaryOperator = {
+    text: String,
+    precendence: Number,
+    createNode: Function,
+};
+
+type BinaryOperator = {
+    text: String,
+    precendence: Number,
+    createNode: Function,
+    associativity: LEFT | RIGHT,
+    parse: Function,
+};
+
+const UNARY = Symbol(),
+    BINARY = Symbol(),
+    TAG = Symbol(),
+    TEST = Symbol();
+export default class Parser {
+    constructor(tokenStream, options) {
+        this.tokens = tokenStream;
+        this[UNARY] = {};
+        this[BINARY] = {};
+        this[TAG] = {};
+        this[TEST] = {};
+        this.options = Object.assign(
+            {},
+            {
+                ignoreComments: true,
+                ignoreHtmlComments: true,
+                ignoreDeclarations: true,
+                decodeEntities: true,
+                preserveSourceLiterally: false,
+                allowUnknownTags: false,
+                multiTags: {}, // e.g. { "nav": ["endnav"], "switch": ["case", "default", "endswitch"]}
+            },
+            options
+        );
+        // If there are custom multi tags, then we allow all custom tags
+        if (Object.keys(this.options.multiTags).length > 0) {
+            this.options.allowUnknownTags = true;
+        }
+    }
+
+    applyExtension(ext) {
+        if (ext.tags) {
+            for (const tag of ext.tags) {
+                this.addTag(tag);
+            }
+        }
+        if (ext.unaryOperators) {
+            for (const op of ext.unaryOperators) {
+                this.addUnaryOperator(op);
+            }
+        }
+        if (ext.binaryOperators) {
+            for (const op of ext.binaryOperators) {
+                this.addBinaryOperator(op);
+            }
+        }
+        if (ext.tests) {
+            for (const test of ext.tests) {
+                this.addTest(test);
+            }
+        }
+    }
+
+    addUnaryOperator(op: UnaryOperator) {
+        this[UNARY][op.text] = op;
+        return this;
+    }
+
+    addBinaryOperator(op: BinaryOperator) {
+        this[BINARY][op.text] = op;
+        return this;
+    }
+
+    addTag(tag) {
+        this[TAG][tag.name] = tag;
+        return this;
+    }
+
+    addTest(test) {
+        this[TEST][test.text] = test;
+    }
+
+    hasTest(test) {
+        return !!this[TEST][test];
+    }
+
+    getTest(test) {
+        return this[TEST][test];
+    }
+
+    isUnary(token) {
+        return token.type === Types.OPERATOR && !!this[UNARY][token.text];
+    }
+
+    getBinaryOperator(token) {
+        return token.type === Types.OPERATOR && this[BINARY][token.text];
+    }
+
+    parse(test = null) {
+        let tokens = this.tokens,
+            p = setStartFromToken(new n.SequenceExpression(), tokens.la(0));
+        while (!tokens.test(Types.EOF)) {
+            const token = tokens.next();
+            if (!p) {
+                p = setStartFromToken(new n.SequenceExpression(), token);
+            }
+            if (test && test(tokens.la(0).text, token, tokens)) {
+                setEndFromToken(p, token);
+                return p;
+            }
+            switch (token.type) {
+                case Types.EXPRESSION_START: {
+                    const expression = this.matchExpression();
+                    const statement = new n.PrintExpressionStatement(
+                        expression
+                    );
+                    const endToken = tokens.expect(Types.EXPRESSION_END);
+                    setStartFromToken(statement, token);
+                    setEndFromToken(statement, endToken);
+                    setEndFromToken(p, endToken);
+                    statement.trimLeft = !!expression.trimLeft;
+                    statement.trimRight = !!expression.trimRight;
+                    p.add(statement);
+
+                    break;
+                }
+                case Types.TAG_START:
+                    p.add(this.matchTag());
+                    break;
+                case Types.TEXT: {
+                    const textStringLiteral = createNode(
+                        n.StringLiteral,
+                        token,
+                        token.text
+                    );
+                    const textTextStatement = createNode(
+                        n.PrintTextStatement,
+                        token,
+                        textStringLiteral
+                    );
+                    p.add(textTextStatement);
+                    break;
+                }
+                case Types.ENTITY: {
+                    const entityStringLiteral = createNode(
+                        n.StringLiteral,
+                        token,
+                        !this.options.decodeEntities ||
+                            this.options.preserveSourceLiterally
+                            ? token.text
+                            : he.decode(token.text)
+                    );
+                    const entityTextStatement = createNode(
+                        n.PrintTextStatement,
+                        token,
+                        entityStringLiteral
+                    );
+                    p.add(entityTextStatement);
+                    break;
+                }
+                case Types.ELEMENT_START:
+                    p.add(this.matchElement());
+                    break;
+                case Types.DECLARATION_START: {
+                    const declarationNode = this.matchDeclaration();
+                    if (!this.options.ignoreDeclarations) {
+                        p.add(declarationNode);
+                    }
+                    break;
+                }
+                case Types.COMMENT:
+                    if (!this.options.ignoreComments) {
+                        const stringLiteral = createNode(
+                            n.StringLiteral,
+                            token,
+                            token.text
+                        );
+                        const twigComment = createNode(
+                            n.TwigComment,
+                            token,
+                            stringLiteral
+                        );
+                        p.add(twigComment);
+                    }
+                    break;
+                case Types.HTML_COMMENT:
+                    if (!this.options.ignoreHtmlComments) {
+                        const stringLiteral = createNode(
+                            n.StringLiteral,
+                            token,
+                            token.text
+                        );
+                        const htmlComment = createNode(
+                            n.HtmlComment,
+                            token,
+                            stringLiteral
+                        );
+                        p.add(htmlComment);
+                    }
+                    break;
+            }
+        }
+        return p;
+    }
+
+    /**
+     * e.g., <!DOCTYPE html>
+     */
+    matchDeclaration() {
+        const tokens = this.tokens,
+            declarationStartToken = tokens.la(-1);
+        let declarationType = null,
+            currentToken = null;
+
+        if (!(declarationType = tokens.nextIf(Types.SYMBOL))) {
+            this.error({
+                title: 'Expected declaration start',
+                pos: declarationStartToken.pos,
+                advice:
+                    "After '<!', an unquoted symbol like DOCTYPE is expected",
+            });
+        }
+
+        const declaration = new n.Declaration(declarationType.text);
+        while ((currentToken = tokens.next())) {
+            if (currentToken.type === Types.SYMBOL) {
+                const symbol = createNode(
+                    n.Identifier,
+                    currentToken,
+                    currentToken.text
+                );
+                declaration.parts.push(symbol);
+            } else if (currentToken.type === Types.STRING_START) {
+                const stringToken = tokens.expect(Types.STRING);
+                declaration.parts.push(
+                    createNode(n.StringLiteral, stringToken, stringToken.text)
+                );
+                tokens.expect(Types.STRING_END);
+            } else if (currentToken.type === Types.EXPRESSION_START) {
+                const expression = this.matchExpression();
+                declaration.parts.push(
+                    copyLoc(
+                        new n.PrintExpressionStatement(expression),
+                        expression
+                    )
+                );
+                tokens.expect(Types.EXPRESSION_END);
+            } else if (currentToken.type === Types.ELEMENT_END) {
+                break;
+            } else {
+                this.error({
+                    title: 'Expected string, symbol, or expression',
+                    pos: currentToken.pos,
+                    advice:
+                        'Only strings or symbols can be part of a declaration',
+                });
+            }
+        }
+        setStartFromToken(declaration, declarationStartToken);
+        setEndFromToken(declaration, currentToken);
+
+        return declaration;
+    }
+
+    /**
+     * matchElement = '<' SYMBOL attributes* '/'? '>' (children)* '<' '/' SYMBOL '>'
+     * attributes = SYMBOL '=' (matchExpression | matchString)
+     *              | matchExpression
+     */
+    matchElement() {
+        const tokens = this.tokens,
+            elementNameToken = tokens.la(0),
+            tagStartToken = tokens.la(-1);
+        let elementName;
+        if (!(elementName = tokens.nextIf(Types.SYMBOL))) {
+            this.error({
+                title: 'Expected element start',
+                pos: elementNameToken.pos,
+                advice:
+                    tokens.lat(0) === Types.SLASH
+                        ? `Unexpected closing "${
+                              tokens.la(1).text
+                          }" tag. Seems like your DOM is out of control.`
+                        : 'Expected an element to start',
+            });
+        }
+
+        const element = new n.Element(elementName.text);
+
+        this.matchAttributes(element, tokens);
+
+        if (tokens.nextIf(Types.SLASH)) {
+            tokens.expect(Types.ELEMENT_END);
+            element.selfClosing = true;
+        } else {
+            tokens.expect(Types.ELEMENT_END);
+            if (voidElements[elementName.text]) {
+                element.selfClosing = true;
+            } else {
+                element.children = this.parse(function(_, token, tokens) {
+                    if (
+                        token.type === Types.ELEMENT_START &&
+                        tokens.lat(0) === Types.SLASH
+                    ) {
+                        const name = tokens.la(1);
+                        if (
+                            name.type === Types.SYMBOL &&
+                            name.text === elementName.text
+                        ) {
+                            tokens.next(); // SLASH
+                            tokens.next(); // elementName
+                            tokens.expect(Types.ELEMENT_END);
+                            return true;
+                        }
+                    }
+                    return false;
+                }).expressions;
+            }
+        }
+
+        setStartFromToken(element, tagStartToken);
+        setEndFromToken(element, tokens.la(-1));
+        setMarkFromToken(element, 'elementNameLoc', elementNameToken);
+
+        return element;
+    }
+
+    matchAttributes(element, tokens) {
+        while (
+            tokens.lat(0) !== Types.SLASH &&
+            tokens.lat(0) !== Types.ELEMENT_END
+        ) {
+            const key = tokens.nextIf(Types.SYMBOL);
+            if (key) {
+                const keyNode = new n.Identifier(key.text);
+                setStartFromToken(keyNode, key);
+                setEndFromToken(keyNode, key);
+
+                // match an attribute
+                if (tokens.nextIf(Types.ASSIGNMENT)) {
+                    const start = tokens.expect(Types.STRING_START);
+                    let canBeString = true,
+                        nodes = [],
+                        token;
+                    while (!tokens.test(Types.STRING_END)) {
+                        if (
+                            canBeString &&
+                            (token = tokens.nextIf(Types.STRING))
+                        ) {
+                            nodes[nodes.length] = createNode(
+                                n.StringLiteral,
+                                token,
+                                token.text
+                            );
+                            canBeString = false;
+                        } else if (
+                            (token = tokens.nextIf(Types.EXPRESSION_START))
+                        ) {
+                            nodes[nodes.length] = this.matchExpression();
+                            tokens.expect(Types.EXPRESSION_END);
+                            canBeString = true;
+                        } else {
+                            break;
+                        }
+                    }
+                    tokens.expect(Types.STRING_END);
+                    if (!nodes.length) {
+                        const node = createNode(n.StringLiteral, start, '');
+                        nodes.push(node);
+                    }
+
+                    let expr = nodes[0];
+                    for (let i = 1, len = nodes.length; i < len; i++) {
+                        const { line, column } = expr.loc.start;
+                        expr = new n.BinaryConcatExpression(expr, nodes[i]);
+                        expr.loc.start.line = line;
+                        expr.loc.start.column = column;
+                        copyEnd(expr, expr.right);
+                    }
+                    // Distinguish between BinaryConcatExpression generated by
+                    // this Parser (implicit before parsing), and those that the
+                    // user wrote explicitly.
+                    if (nodes.length > 1) {
+                        expr.wasImplicitConcatenation = true;
+                    }
+                    const attr = new n.Attribute(keyNode, expr);
+                    copyStart(attr, keyNode);
+                    copyEnd(attr, expr);
+                    element.attributes.push(attr);
+                } else {
+                    element.attributes.push(
+                        copyLoc(new n.Attribute(keyNode), keyNode)
+                    );
+                }
+            } else if (tokens.nextIf(Types.EXPRESSION_START)) {
+                element.attributes.push(this.matchExpression());
+                tokens.expect(Types.EXPRESSION_END);
+            } else {
+                this.error({
+                    title: 'Invalid token',
+                    pos: tokens.la(0).pos,
+                    advice:
+                        'A tag must consist of attributes or expressions. Twig Tags are not allowed.',
+                });
+            }
+        }
+    }
+
+    error(options, metadata = {}) {
+        this.tokens.error(
+            options.title,
+            options.pos,
+            options.advice,
+            1,
+            metadata
+        );
+    }
+
+    getGenericParserFor(tagName) {
+        if (this.options.multiTags[tagName]) {
+            return createMultiTagParser(
+                tagName,
+                this.options.multiTags[tagName]
+            );
+        } else {
+            return GenericTagParser;
+        }
+    }
+
+    matchTag() {
+        const tokens = this.tokens;
+        const tagStartToken = tokens.la(-1);
+
+        const tag = tokens.expect(Types.SYMBOL);
+        let parser = this[TAG][tag.text];
+        let isUsingGenericParser = false;
+        if (!parser) {
+            if (this.options.allowUnknownTags) {
+                parser = this.getGenericParserFor(tag.text);
+                isUsingGenericParser = true;
+            } else {
+                tokens.error(
+                    `Unknown tag "${tag.text}"`,
+                    tag.pos,
+                    `Expected a known tag such as\n- ${Object.getOwnPropertyNames(
+                        this[TAG]
+                    ).join('\n- ')}`,
+                    tag.length
+                );
+            }
+        }
+
+        const result = parser.parse(this, tag);
+        const tagEndToken = tokens.la(-1);
+        if (!isUsingGenericParser) {
+            result.trimLeft = tagStartToken.text.endsWith('-');
+            result.trimRight = tagEndToken.text.startsWith('-');
+        }
+
+        setStartFromToken(result, tagStartToken);
+        setEndFromToken(result, tagEndToken);
+        setMarkFromToken(result, 'tagNameLoc', tag);
+
+        return result;
+    }
+
+    matchExpression(precedence = 0) {
+        const tokens = this.tokens,
+            exprStartToken = tokens.la(0);
+        let token,
+            op,
+            trimLeft = false;
+
+        // Check for {{- (trim preceding whitespace)
+        if (
+            tokens.la(-1).type === Types.EXPRESSION_START &&
+            tokens.la(-1).text.endsWith('-')
+        ) {
+            trimLeft = true;
+        }
+
+        let expr = this.getPrimary();
+        while (
+            (token = tokens.la(0)) &&
+            token.type !== Types.EOF &&
+            (op = this.getBinaryOperator(token)) &&
+            op.precedence >= precedence
+        ) {
+            const opToken = tokens.next(); // consume the operator
+            if (op.parse) {
+                expr = op.parse(this, opToken, expr);
+            } else {
+                const expr1 = this.matchExpression(
+                    op.associativity === LEFT
+                        ? op.precedence + 1
+                        : op.precedence
+                );
+                expr = op.createNode(token, expr, expr1);
+            }
+            token = tokens.la(0);
+        }
+
+        var result = expr;
+        if (precedence === 0) {
+            setEndFromToken(expr, tokens.la(-1));
+            result = this.matchConditionalExpression(expr);
+            // Update the local token variable because the stream pointer already advanced.
+            token = tokens.la(0);
+        }
+
+        // Check for -}} (trim following whitespace)
+        if (token.type === Types.EXPRESSION_END && token.text.startsWith('-')) {
+            result.trimRight = true;
+        }
+        if (trimLeft) {
+            result.trimLeft = trimLeft;
+        }
+
+        const exprEndToken = tokens.la(-1);
+        setStartFromToken(result, exprStartToken);
+        setEndFromToken(result, exprEndToken);
+
+        return result;
+    }
+
+    getPrimary() {
+        let tokens = this.tokens,
+            token = tokens.la(0);
+        if (this.isUnary(token)) {
+            const op = this[UNARY][token.text];
+            tokens.next(); // consume operator
+            const expr = this.matchExpression(op.precedence);
+            return this.matchPostfixExpression(op.createNode(token, expr));
+        } else if (tokens.test(Types.LPAREN)) {
+            tokens.next(); // consume '('
+            const expr = this.matchExpression();
+            tokens.expect(Types.RPAREN);
+            return this.matchPostfixExpression(expr);
+        }
+
+        return this.matchPrimaryExpression();
+    }
+
+    matchPrimaryExpression() {
+        let tokens = this.tokens,
+            token = tokens.la(0),
+            node;
+        switch (token.type) {
+            case Types.NULL:
+                node = createNode(n.NullLiteral, tokens.next());
+                break;
+            case Types.FALSE:
+                node = createNode(n.BooleanLiteral, tokens.next(), false);
+                break;
+            case Types.TRUE:
+                node = createNode(n.BooleanLiteral, tokens.next(), true);
+                break;
+            case Types.SYMBOL:
+                tokens.next();
+                if (tokens.test(Types.LPAREN)) {
+                    // SYMBOL '(' arguments* ')'
+                    node = new n.CallExpression(
+                        createNode(n.Identifier, token, token.text),
+                        this.matchArguments()
+                    );
+                    copyStart(node, node.callee);
+                    setEndFromToken(node, tokens.la(-1)); // ')'
+                } else {
+                    node = createNode(n.Identifier, token, token.text);
+                }
+                break;
+            case Types.NUMBER:
+                node = createNode(
+                    n.NumericLiteral,
+                    token,
+                    Number(tokens.next())
+                );
+                break;
+            case Types.STRING_START:
+                node = this.matchStringExpression();
+                break;
+            // potentially missing: OPERATOR type
+            default:
+                if (token.type === Types.LBRACE) {
+                    node = this.matchArray();
+                } else if (token.type === Types.LBRACKET) {
+                    node = this.matchMap();
+                } else {
+                    this.error(
+                        {
+                            title:
+                                'Unexpected token "' +
+                                token.type +
+                                '" of value "' +
+                                token.text +
+                                '"',
+                            pos: token.pos,
+                        },
+                        {
+                            errorType: 'UNEXPECTED_TOKEN',
+                            tokenText: token.text,
+                            tokenType: token.type,
+                        }
+                    );
+                }
+                break;
+        }
+
+        return this.matchPostfixExpression(node);
+    }
+
+    matchStringExpression() {
+        let canBeString = true,
+            token;
+        const tokens = this.tokens,
+            nodes = [],
+            stringStart = tokens.expect(Types.STRING_START);
+        while (!tokens.test(Types.STRING_END)) {
+            if (canBeString && (token = tokens.nextIf(Types.STRING))) {
+                nodes[nodes.length] = createNode(
+                    n.StringLiteral,
+                    token,
+                    token.text
+                );
+                canBeString = false;
+            } else if ((token = tokens.nextIf(Types.INTERPOLATION_START))) {
+                nodes[nodes.length] = this.matchExpression();
+                tokens.expect(Types.INTERPOLATION_END);
+                canBeString = true;
+            } else {
+                break;
+            }
+        }
+        const stringEnd = tokens.expect(Types.STRING_END);
+
+        if (!nodes.length) {
+            return setEndFromToken(
+                createNode(n.StringLiteral, stringStart, ''),
+                stringEnd
+            );
+        }
+
+        let expr = nodes[0];
+        for (let i = 1, len = nodes.length; i < len; i++) {
+            const { line, column } = expr.loc.start;
+            expr = new n.BinaryConcatExpression(expr, nodes[i]);
+            expr.loc.start.line = line;
+            expr.loc.start.column = column;
+            copyEnd(expr, expr.right);
+        }
+
+        if (nodes.length > 1) {
+            expr.wasImplicitConcatenation = true;
+        }
+
+        setStartFromToken(expr, stringStart);
+        setEndFromToken(expr, stringEnd);
+
+        return expr;
+    }
+
+    matchConditionalExpression(test: Node) {
+        const tokens = this.tokens;
+        let condition = test,
+            consequent,
+            alternate;
+        while (tokens.nextIf(Types.QUESTION_MARK)) {
+            if (!tokens.nextIf(Types.COLON)) {
+                consequent = this.matchExpression();
+                if (tokens.nextIf(Types.COLON)) {
+                    alternate = this.matchExpression();
+                } else {
+                    alternate = null;
+                }
+            } else {
+                consequent = null;
+                alternate = this.matchExpression();
+            }
+            const { line, column } = condition.loc.start;
+            condition = new n.ConditionalExpression(
+                condition,
+                consequent,
+                alternate
+            );
+            condition.loc.start = { line, column };
+            copyEnd(condition, alternate || consequent);
+        }
+        return condition;
+    }
+
+    matchArray() {
+        let tokens = this.tokens,
+            array = new n.ArrayExpression(),
+            start = tokens.expect(Types.LBRACE);
+        setStartFromToken(array, start);
+        while (!tokens.test(Types.RBRACE) && !tokens.test(Types.EOF)) {
+            array.elements.push(this.matchExpression());
+            if (!tokens.test(Types.RBRACE)) {
+                tokens.expect(Types.COMMA);
+                // support trailing commas
+                if (tokens.test(Types.RBRACE)) {
+                    break;
+                }
+            }
+        }
+        setEndFromToken(array, tokens.expect(Types.RBRACE));
+        return array;
+    }
+
+    matchMap() {
+        let tokens = this.tokens,
+            token,
+            obj = new n.ObjectExpression(),
+            startToken = tokens.expect(Types.LBRACKET);
+        setStartFromToken(obj, startToken);
+        while (!tokens.test(Types.RBRACKET) && !tokens.test(Types.EOF)) {
+            let computed = false,
+                key,
+                value;
+            if (tokens.test(Types.STRING_START)) {
+                key = this.matchStringExpression();
+                if (!n.is(key, 'StringLiteral')) {
+                    computed = true;
+                }
+            } else if ((token = tokens.nextIf(Types.SYMBOL))) {
+                key = createNode(n.Identifier, token, token.text);
+            } else if ((token = tokens.nextIf(Types.NUMBER))) {
+                key = createNode(n.NumericLiteral, token, Number(token.text));
+            } else if (tokens.test(Types.LPAREN)) {
+                key = this.matchExpression();
+                computed = true;
+            } else {
+                this.error({
+                    title: 'Invalid map key',
+                    pos: tokens.la(0).pos,
+                    advice:
+                        'Key must be a string, symbol or a number but was ' +
+                        tokens.next(),
+                });
+            }
+            tokens.expect(Types.COLON);
+            value = this.matchExpression();
+            const prop = new n.ObjectProperty(key, value, computed);
+            copyStart(prop, key);
+            copyEnd(prop, value);
+            obj.properties.push(prop);
+            if (!tokens.test(Types.RBRACKET)) {
+                tokens.expect(Types.COMMA);
+                // support trailing comma
+                if (tokens.test(Types.RBRACKET)) {
+                    break;
+                }
+            }
+        }
+        setEndFromToken(obj, tokens.expect(Types.RBRACKET));
+        return obj;
+    }
+
+    matchPostfixExpression(expr) {
+        const tokens = this.tokens;
+        let node = expr;
+        while (!tokens.test(Types.EOF)) {
+            if (tokens.test(Types.DOT) || tokens.test(Types.LBRACE)) {
+                node = this.matchSubscriptExpression(node);
+            } else if (tokens.test(Types.PIPE)) {
+                tokens.next();
+                node = this.matchFilterExpression(node);
+            } else {
+                break;
+            }
+        }
+
+        return node;
+    }
+
+    matchSubscriptExpression(node) {
+        let tokens = this.tokens,
+            op = tokens.next();
+        if (op.type === Types.DOT) {
+            let token = tokens.next(),
+                computed = false,
+                property;
+            if (token.type === Types.SYMBOL) {
+                property = createNode(n.Identifier, token, token.text);
+            } else if (token.type === Types.NUMBER) {
+                property = createNode(
+                    n.NumericLiteral,
+                    token,
+                    Number(token.text)
+                );
+                computed = true;
+            } else {
+                this.error({
+                    title: 'Invalid token',
+                    pos: token.pos,
+                    advice:
+                        'Expected number or symbol, found ' +
+                        token +
+                        ' instead',
+                });
+            }
+
+            const memberExpr = new n.MemberExpression(node, property, computed);
+            copyStart(memberExpr, node);
+            copyEnd(memberExpr, property);
+            if (tokens.test(Types.LPAREN)) {
+                const callExpr = new n.CallExpression(
+                    memberExpr,
+                    this.matchArguments()
+                );
+                copyStart(callExpr, memberExpr);
+                setEndFromToken(callExpr, tokens.la(-1));
+                return callExpr;
+            }
+            return memberExpr;
+        } else {
+            let arg, start;
+            if (tokens.test(Types.COLON)) {
+                // slice
+                tokens.next();
+                start = null;
+            } else {
+                arg = this.matchExpression();
+                if (tokens.test(Types.COLON)) {
+                    start = arg;
+                    arg = null;
+                    tokens.next();
+                }
+            }
+
+            if (arg) {
+                return setEndFromToken(
+                    copyStart(new n.MemberExpression(node, arg, true), node),
+                    tokens.expect(Types.RBRACE)
+                );
+            } else {
+                // slice
+                const result = new n.SliceExpression(
+                    node,
+                    start,
+                    tokens.test(Types.RBRACE) ? null : this.matchExpression()
+                );
+                copyStart(result, node);
+                setEndFromToken(result, tokens.expect(Types.RBRACE));
+                return result;
+            }
+        }
+    }
+
+    matchFilterExpression(node) {
+        let tokens = this.tokens,
+            target = node;
+        while (!tokens.test(Types.EOF)) {
+            let token = tokens.expect(Types.SYMBOL),
+                name = createNode(n.Identifier, token, token.text),
+                args;
+            if (tokens.test(Types.LPAREN)) {
+                args = this.matchArguments();
+            } else {
+                args = [];
+            }
+            const newTarget = new n.FilterExpression(target, name, args);
+            copyStart(newTarget, target);
+            if (newTarget.arguments.length) {
+                copyEnd(
+                    newTarget,
+                    newTarget.arguments[newTarget.arguments.length - 1]
+                );
+            } else {
+                copyEnd(newTarget, target);
+            }
+            target = newTarget;
+
+            if (!tokens.test(Types.PIPE) || tokens.test(Types.EOF)) {
+                break;
+            }
+
+            tokens.next(); // consume '|'
+        }
+        return target;
+    }
+
+    matchArguments() {
+        let tokens = this.tokens,
+            args = [];
+        tokens.expect(Types.LPAREN);
+        while (!tokens.test(Types.RPAREN) && !tokens.test(Types.EOF)) {
+            if (
+                tokens.test(Types.SYMBOL) &&
+                tokens.lat(1) === Types.ASSIGNMENT
+            ) {
+                const name = tokens.next();
+                tokens.next();
+                const value = this.matchExpression();
+                const arg = new n.NamedArgumentExpression(
+                    createNode(n.Identifier, name, name.text),
+                    value
+                );
+                copyEnd(arg, value);
+                args.push(arg);
+            } else {
+                args.push(this.matchExpression());
+            }
+
+            if (!tokens.test(Types.COMMA)) {
+                tokens.expect(Types.RPAREN);
+                return args;
+            }
+            tokens.expect(Types.COMMA);
+        }
+        tokens.expect(Types.RPAREN);
+        return args;
+    }
+}

--- a/src/melody/melody-parser/TokenStream.js
+++ b/src/melody/melody-parser/TokenStream.js
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    EOF_TOKEN,
+    ERROR,
+    ERROR_TABLE,
+    COMMENT,
+    WHITESPACE,
+    HTML_COMMENT,
+    TAG_START,
+    TAG_END,
+    EXPRESSION_START,
+    EXPRESSION_END,
+    TEXT,
+    STRING,
+} from './TokenTypes';
+import trimEnd from 'lodash/trimEnd';
+import trimStart from 'lodash/trimStart';
+import codeFrame from 'melody-code-frame';
+
+const TOKENS = Symbol(),
+    LENGTH = Symbol();
+
+export default class TokenStream {
+    constructor(lexer, options) {
+        this.input = lexer;
+        this.index = 0;
+        const mergedOptions = Object.assign(
+            {},
+            {
+                ignoreComments: true,
+                ignoreHtmlComments: true,
+                ignoreWhitespace: true,
+                applyWhitespaceTrimming: true,
+            },
+            options
+        );
+        this[TOKENS] = getAllTokens(lexer, mergedOptions);
+        this[LENGTH] = this[TOKENS].length;
+
+        if (
+            this[TOKENS].length &&
+            this[TOKENS][this[TOKENS].length - 1].type === ERROR
+        ) {
+            const errorToken = this[TOKENS][this[TOKENS].length - 1];
+            this.error(
+                errorToken.message,
+                errorToken.pos,
+                errorToken.advice,
+                errorToken.endPos.index - errorToken.pos.index || 1
+            );
+        }
+    }
+
+    la(offset) {
+        var index = this.index + offset;
+        return index < this[LENGTH] ? this[TOKENS][index] : EOF_TOKEN;
+    }
+
+    lat(offset) {
+        return this.la(offset).type;
+    }
+
+    test(type, text) {
+        const token = this.la(0);
+        return token.type === type && (!text || token.text === text);
+    }
+
+    next() {
+        if (this.index === this[LENGTH]) {
+            return EOF_TOKEN;
+        }
+        const token = this[TOKENS][this.index];
+        this.index++;
+        return token;
+    }
+
+    nextIf(type, text) {
+        if (this.test(type, text)) {
+            return this.next();
+        }
+        return false;
+    }
+
+    expect(type, text) {
+        const token = this.la(0);
+        if (token.type === type && (!text || token.text === text)) {
+            return this.next();
+        }
+        this.error(
+            'Invalid Token',
+            token.pos,
+            `Expected ${ERROR_TABLE[type] ||
+                type ||
+                text} but found ${ERROR_TABLE[token.type] ||
+                token.type ||
+                token.text} instead.`,
+            token.length
+        );
+    }
+
+    error(message, pos, advice, length = 1, metadata = {}) {
+        let errorMessage = `ERROR: ${message}\n`;
+        errorMessage += codeFrame({
+            rawLines: this.input.source,
+            lineNumber: pos.line,
+            colNumber: pos.column,
+            length,
+            tokens: getAllTokens(this.input, {
+                ignoreWhitespace: false,
+                ignoreComments: false,
+                ignoreHtmlComments: false,
+            }),
+        });
+        if (advice) {
+            errorMessage += '\n\n' + advice;
+        }
+        const result = new Error(errorMessage);
+        Object.assign(result, metadata);
+        throw result;
+    }
+}
+
+function getAllTokens(lexer, options) {
+    let token,
+        tokens = [],
+        acceptWhitespaceControl = false,
+        trimNext = false;
+    while ((token = lexer.next()) !== EOF_TOKEN) {
+        const shouldTrimNext = trimNext;
+        trimNext = false;
+        if (acceptWhitespaceControl) {
+            switch (token.type) {
+                case EXPRESSION_START:
+                case TAG_START:
+                    if (token.text[token.text.length - 1] === '-') {
+                        tokens[tokens.length - 1].text = trimEnd(
+                            tokens[tokens.length - 1].text
+                        );
+                    }
+                    break;
+                case EXPRESSION_END:
+                case TAG_END:
+                    if (token.text[0] === '-') {
+                        trimNext = true;
+                    }
+                    break;
+                case COMMENT:
+                    if (tokens[tokens.length - 1].type === TEXT) {
+                        tokens[tokens.length - 1].text = trimEnd(tokens.text);
+                    }
+                    trimNext = true;
+                    break;
+            }
+        }
+        if (shouldTrimNext && (token.type === TEXT || token.type === STRING)) {
+            token.text = trimStart(token.text);
+        }
+        if (
+            (token.type !== COMMENT || !options.ignoreComments) &&
+            (token.type !== WHITESPACE || !options.ignoreWhitespace) &&
+            (token.type !== HTML_COMMENT || !options.ignoreHtmlComments)
+        ) {
+            tokens[tokens.length] = token;
+        }
+        acceptWhitespaceControl = options.applyWhitespaceTrimming;
+        if (token.type === ERROR) {
+            return tokens;
+        }
+    }
+    return tokens;
+}

--- a/src/melody/melody-parser/TokenTypes.js
+++ b/src/melody/melody-parser/TokenTypes.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const EXPRESSION_START = 'expressionStart';
+export const EXPRESSION_END = 'expressionEnd';
+export const TAG_START = 'tagStart';
+export const TAG_END = 'tagEnd';
+export const INTERPOLATION_START = 'interpolationStart';
+export const INTERPOLATION_END = 'interpolationEnd';
+export const STRING_START = 'stringStart';
+export const STRING_END = 'stringEnd';
+export const DECLARATION_START = 'declarationStart';
+export const COMMENT = 'comment';
+export const WHITESPACE = 'whitespace';
+export const HTML_COMMENT = 'htmlComment';
+export const TEXT = 'text';
+export const ENTITY = 'entity';
+export const SYMBOL = 'symbol';
+export const STRING = 'string';
+export const OPERATOR = 'operator';
+export const TRUE = 'true';
+export const FALSE = 'false';
+export const NULL = 'null';
+export const LBRACE = '[';
+export const RBRACE = ']';
+export const LPAREN = '(';
+export const RPAREN = ')';
+export const LBRACKET = '{';
+export const RBRACKET = '}';
+export const COLON = ':';
+export const COMMA = ',';
+export const DOT = '.';
+export const PIPE = '|';
+export const QUESTION_MARK = '?';
+export const ASSIGNMENT = '=';
+export const ELEMENT_START = '<';
+export const SLASH = '/';
+export const ELEMENT_END = '>';
+export const NUMBER = 'number';
+export const EOF = 'EOF';
+export const ERROR = 'ERROR';
+export const EOF_TOKEN = {
+    type: EOF,
+    pos: {
+        index: -1,
+        line: -1,
+        pos: -1,
+    },
+    end: -1,
+    length: 0,
+    source: null,
+    text: '',
+};
+
+export const ERROR_TABLE = {
+    [EXPRESSION_END]: 'expression end "}}"',
+    [EXPRESSION_START]: 'expression start "{{"',
+    [TAG_START]: 'tag start "{%"',
+    [TAG_END]: 'tag end "%}"',
+    [INTERPOLATION_START]: 'interpolation start "#{"',
+    [INTERPOLATION_END]: 'interpolation end "}"',
+};

--- a/src/melody/melody-parser/elementInfo.js
+++ b/src/melody/melody-parser/elementInfo.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// https://www.w3.org/TR/html5/syntax.html#void-elements
+export const voidElements = {
+    area: true,
+    base: true,
+    br: true,
+    col: true,
+    embed: true,
+    hr: true,
+    img: true,
+    input: true,
+    keygen: true,
+    link: true,
+    meta: true,
+    param: true,
+    source: true,
+    track: true,
+    wbr: true,
+};
+
+export const rawTextElements = {
+    script: true,
+    style: true,
+};
+
+export const escapableRawTextElements = {
+    textarea: true,
+    title: true,
+};

--- a/src/melody/melody-parser/index.js
+++ b/src/melody/melody-parser/index.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Parser from './Parser';
+import TokenStream from './TokenStream';
+import * as Types from './TokenTypes';
+import Lexer from './Lexer';
+import { EOF, CharStream } from './CharStream';
+import { LEFT, RIGHT } from './Associativity';
+import {
+    setStartFromToken,
+    setEndFromToken,
+    copyStart,
+    copyEnd,
+    copyLoc,
+    getNodeSource,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+    isMelodyExtension,
+} from './util';
+
+function parse(code, options, ...extensions) {
+    return createExtendedParser(code, options, ...extensions).parse();
+}
+
+function createExtendedParser(code, options, ...extensions) {
+    let passedOptions = options;
+    const passedExtensions = extensions;
+    if (isMelodyExtension(options)) {
+        // Variant without options parameter: createExtendedParser(code, ...extensions)
+        passedOptions = undefined;
+        passedExtensions.unshift(options);
+    }
+    const lexer = createExtendedLexer(code, options, ...passedExtensions);
+    const parser = new Parser(
+        new TokenStream(lexer, passedOptions),
+        passedOptions
+    );
+    for (const ext of passedExtensions) {
+        parser.applyExtension(ext);
+    }
+    return parser;
+}
+
+function createExtendedLexer(code, options, ...extensions) {
+    let passedOptions = options;
+    const passedExtensions = extensions;
+    if (isMelodyExtension(options)) {
+        // Variant without options parameter: createExtendedLexer(code, ...extensions)
+        passedOptions = undefined;
+        passedExtensions.unshift(options);
+    }
+    const lexer = new Lexer(new CharStream(code), passedOptions);
+    for (const ext of passedExtensions) {
+        lexer.applyExtension(ext);
+    }
+    return lexer;
+}
+
+export {
+    Parser,
+    TokenStream,
+    Lexer,
+    EOF,
+    CharStream,
+    LEFT,
+    RIGHT,
+    parse,
+    createExtendedLexer,
+    createExtendedParser,
+    setStartFromToken,
+    setEndFromToken,
+    copyStart,
+    copyEnd,
+    copyLoc,
+    getNodeSource,
+    createNode,
+    hasTagStartTokenTrimLeft,
+    hasTagEndTokenTrimRight,
+    Types,
+};

--- a/src/melody/melody-parser/util.js
+++ b/src/melody/melody-parser/util.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export function setStartFromToken(node, { pos: { index, line, column } }) {
+    node.loc.start = { line, column, index };
+    return node;
+}
+
+export function setEndFromToken(node, { pos: { line, column }, end }) {
+    node.loc.end = { line, column, index: end };
+    return node;
+}
+
+export function setMarkFromToken(
+    node,
+    propertyName,
+    { pos: { index, line, column } }
+) {
+    node[propertyName] = { line, column, index };
+    return node;
+}
+
+export function copyStart(
+    node,
+    {
+        loc: {
+            start: { line, column, index },
+        },
+    }
+) {
+    node.loc.start.line = line;
+    node.loc.start.column = column;
+    node.loc.start.index = index;
+    return node;
+}
+
+export function copyEnd(node, end) {
+    node.loc.end.line = end.loc.end.line;
+    node.loc.end.column = end.loc.end.column;
+    node.loc.end.index = end.loc.end.index;
+    return node;
+}
+
+export function getNodeSource(node, entireSource) {
+    if (entireSource && node.loc.start && node.loc.end) {
+        return entireSource.substring(node.loc.start.index, node.loc.end.index);
+    }
+    return '';
+}
+
+export function copyLoc(node, { loc: { start, end } }) {
+    node.loc.start.line = start.line;
+    node.loc.start.column = start.column;
+    node.loc.start.index = start.index;
+    node.loc.end.line = end.line;
+    node.loc.end.column = end.column;
+    node.loc.end.index = end.index;
+    return node;
+}
+
+export function createNode(Type, token, ...args) {
+    return setEndFromToken(setStartFromToken(new Type(...args), token), token);
+}
+
+export function startNode(Type, token, ...args) {
+    return setStartFromToken(new Type(...args), token);
+}
+
+export function hasTagStartTokenTrimLeft(token) {
+    return token.text.endsWith('-');
+}
+
+export function hasTagEndTokenTrimRight(token) {
+    return token.text.startsWith('-');
+}
+
+export function isMelodyExtension(obj) {
+    return (
+        obj &&
+        (Array.isArray(obj.binaryOperators) ||
+            typeof obj.filterMap === 'object' ||
+            typeof obj.functionMap === 'object' ||
+            Array.isArray(obj.tags) ||
+            Array.isArray(obj.tests) ||
+            Array.isArray(obj.unaryOperators) ||
+            Array.isArray(obj.visitors))
+    );
+}

--- a/src/melody/melody-traverse/Binding.js
+++ b/src/melody/melody-traverse/Binding.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class Binding {
+    constructor(identifier, scope, path, kind = 'global') {
+        this.identifier = identifier;
+        this.scope = scope;
+        this.path = path;
+        this.kind = kind;
+
+        this.referenced = false;
+        this.references = 0;
+        this.referencePaths = [];
+        this.definitionPaths = [];
+        this.shadowedBinding = null;
+        this.contextual = false;
+
+        this.data = Object.create(null);
+    }
+
+    getData(key) {
+        return this.data[key];
+    }
+
+    setData(key, value) {
+        this.data[key] = value;
+    }
+
+    reference(path) {
+        this.referenced = true;
+        this.references++;
+        this.referencePaths.push(path);
+    }
+
+    // dereference(path) {
+    //   if (path) {
+    //     this.referencePaths.splice(this.referencePaths.indexOf(path), 1);
+    //   }
+    //   this.references--;
+    //   this.referenced = !!this.references;
+    // }
+
+    getRootDefinition() {
+        if (this.shadowedBinding) {
+            return this.shadowedBinding.getRootDefinition();
+        }
+        return this;
+    }
+}

--- a/src/melody/melody-traverse/Path.js
+++ b/src/melody/melody-traverse/Path.js
@@ -1,0 +1,403 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PATH_CACHE_KEY } from 'melody-types';
+import { Node, is } from 'melody-types';
+import { visit } from './traverse';
+import Scope from './Scope';
+
+export default class Path {
+    //region Path creation
+    constructor(parent) {
+        this.parent = parent;
+
+        this.inList = false;
+        this.listKey = null;
+        this.parentKey = null;
+        this.container = null;
+        this.parentPath = null;
+
+        this.key = null;
+        this.node = null;
+        this.type = null;
+
+        this.state = null;
+
+        this.data = Object.create(null);
+        this.contexts = [];
+        this.scope = null;
+        this.visitor = null;
+
+        this.shouldSkip = false;
+        this.shouldStop = false;
+        this.removed = false;
+    }
+
+    static get({ parentPath, parent, container, listKey, key }): Path {
+        const targetNode = container[key],
+            paths =
+                (parent && parent[PATH_CACHE_KEY]) ||
+                (parent ? (parent[PATH_CACHE_KEY] = []) : []);
+        let path;
+
+        for (let i = 0, len = paths.length; i < len; i++) {
+            const candidate = paths[i];
+            if (candidate.node === targetNode) {
+                path = candidate;
+                break;
+            }
+        }
+
+        if (!path) {
+            path = new Path(parent);
+        }
+
+        path.inList = !!listKey;
+        path.listKey = listKey;
+        path.parentKey = listKey || key;
+        path.container = container;
+        path.parentPath = parentPath || path.parentPath;
+
+        path.key = key;
+        path.node = path.container[path.key];
+        path.type = path.node && path.node.type;
+
+        if (!path.node) {
+            /*eslint no-console: off*/
+            console.log(
+                'Path has no node ' + path.parentKey + ' > ' + path.key
+            );
+        }
+        paths.push(path);
+
+        return path;
+    }
+
+    //endregion
+
+    //region Generic data
+    setData(key: string, val: any): any {
+        return (this.data[key] = val);
+    }
+
+    getData(key: string, def?: any): any {
+        const val = this.data[key];
+        if (!val && def) {
+            return (this.data[key] = def);
+        }
+        return val;
+    }
+    //endregion
+
+    //region Context
+    pushContext(context) {
+        this.contexts.push(context);
+        this.setContext(context);
+    }
+
+    popContext() {
+        this.contexts.pop();
+        this.setContext(this.contexts[this.contexts.length - 1]);
+    }
+
+    setContext(context) {
+        this.shouldSkip = false;
+        this.shouldStop = false;
+        this.removed = false;
+        //this.skipKeys = {};
+
+        if (context) {
+            this.context = context;
+            this.state = context.state;
+            this.visitor = context.visitor;
+        }
+
+        this.setScope();
+        return this;
+    }
+
+    getScope(scope: Scope) {
+        if (Node.isScope(this.node)) {
+            if (this.node.type === 'BlockStatement') {
+                return Scope.get(this, scope.getRootScope());
+            }
+            return Scope.get(this, scope);
+        }
+        return scope;
+    }
+
+    setScope() {
+        let target = this.context && this.context.scope;
+
+        if (!target) {
+            let path = this.parentPath;
+            while (path && !target) {
+                target = path.scope;
+                path = path.parentPath;
+            }
+        }
+
+        this.scope = this.getScope(target);
+    }
+
+    visit(): boolean {
+        if (!this.node) {
+            return false;
+        }
+
+        if (call(this, 'enter') || this.shouldSkip) {
+            return this.shouldStop;
+        }
+
+        visit(this.node, this.visitor, this.scope, this.state, this);
+
+        call(this, 'exit');
+
+        return this.shouldStop;
+    }
+
+    skip() {
+        this.shouldSkip = true;
+    }
+
+    stop() {
+        this.shouldStop = true;
+        this.shouldSkip = true;
+    }
+
+    resync() {
+        if (this.removed) {
+            return;
+        }
+
+        if (this.parentPath) {
+            this.parent = this.parentPath.node;
+        }
+
+        if (this.parent && this.inList) {
+            const newContainer = this.parent[this.listKey];
+            if (this.container !== newContainer) {
+                this.container = newContainer || null;
+            }
+        }
+
+        if (this.container && this.node !== this.container[this.key]) {
+            this.key = null;
+            if (Array.isArray(this.container)) {
+                let i, len;
+                for (i = 0, len = this.container.length; i < len; i++) {
+                    if (this.container[i] === this.node) {
+                        this.setKey(i);
+                        break;
+                    }
+                }
+            } else {
+                let key;
+                for (key in this.container) {
+                    if (this.container[key] === this.node) {
+                        this.setKey(key);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    setKey(key) {
+        this.key = key;
+        this.node = this.container[this.key];
+        this.type = this.node && this.node.type;
+    }
+
+    requeue(path = this) {
+        if (path.removed) {
+            return;
+        }
+
+        for (const context of this.contexts) {
+            context.maybeQueue(path);
+        }
+    }
+    //endregion
+
+    //region Modification
+    replaceWith(value) {
+        this.resync();
+
+        const replacement = value instanceof Path ? value.node : value;
+
+        if (this.node === replacement) {
+            return;
+        }
+
+        replaceWith(this, replacement);
+        this.type = replacement.type;
+        this.resync();
+        this.setScope();
+        this.requeue();
+    }
+
+    replaceWithJS(replacement) {
+        this.resync();
+        replaceWith(this, replacement);
+        this.type = replacement.type;
+        this.resync();
+        this.setScope();
+    }
+
+    replaceWithMultipleJS(...replacements) {
+        this.resync();
+
+        if (!this.container) {
+            throw new Error('Path does not have a container');
+        }
+        if (!Array.isArray(this.container)) {
+            throw new Error('Container of path is not an array');
+        }
+
+        this.container.splice(this.key, 1, ...replacements);
+        this.resync();
+        this.updateSiblingKeys(this.key, replacements.length - 1);
+        markRemoved(this);
+        //this.node = replacements[0];
+    }
+
+    remove() {
+        this.resync();
+
+        if (Array.isArray(this.container)) {
+            this.container.splice(this.key, 1);
+            this.updateSiblingKeys(this.key, -1);
+        } else {
+            replaceWith(this, null);
+        }
+
+        markRemoved(this);
+    }
+
+    updateSiblingKeys(fromIndex, incrementBy) {
+        if (!this.parent) {
+            return;
+        }
+
+        const paths: Array<Path> = this.parent[PATH_CACHE_KEY];
+        for (const path of paths) {
+            if (path.key >= fromIndex) {
+                path.key += incrementBy;
+            }
+        }
+    }
+    //endregion
+
+    is(type: String) {
+        return is(this.node, type);
+    }
+
+    findParentPathOfType(type: String) {
+        let path = this.parentPath;
+        while (path && !path.is(type)) {
+            path = path.parentPath;
+        }
+        return path && path.type === type ? path : null;
+    }
+
+    get(key) {
+        let parts: Array = key.split('.'),
+            context = this.context;
+        if (parts.length === 1) {
+            let node = this.node,
+                container = node[key];
+            if (Array.isArray(container)) {
+                return container.map((_, i) =>
+                    Path.get({
+                        listKey: key,
+                        parentPath: this,
+                        parent: node,
+                        container,
+                        key: i,
+                    }).setContext(context)
+                );
+            } else {
+                return Path.get({
+                    parentPath: this,
+                    parent: node,
+                    container: node,
+                    key,
+                }).setContext(context);
+            }
+        } else {
+            let path = this;
+            for (const part of parts) {
+                if (Array.isArray(path)) {
+                    path = path[part];
+                } else {
+                    path = path.get(part);
+                }
+            }
+            return path;
+        }
+    }
+}
+
+function markRemoved(path) {
+    path.shouldSkip = true;
+    path.removed = true;
+    path.node = null;
+}
+
+function replaceWith(path, node) {
+    if (!path.container) {
+        throw new Error('Path does not have a container');
+    }
+
+    path.node = path.container[path.key] = node;
+}
+
+function call(path, key): boolean {
+    if (!path.node) {
+        return false;
+    }
+
+    const visitor = path.visitor[path.node.type];
+    if (!visitor || !visitor[key]) {
+        return false;
+    }
+
+    const fns: Array<Function> = visitor[key];
+    for (let i = 0, len = fns.length; i < len; i++) {
+        const fn = fns[i];
+        if (!fn) {
+            continue;
+        }
+
+        const node = path.node;
+        if (!node) {
+            return true;
+        }
+
+        fn.call(path.state, path, path.state);
+
+        // node has been replaced, requeue
+        if (path.node !== node) {
+            return true;
+        }
+
+        if (path.shouldStop || path.shouldSkip || path.removed) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/melody/melody-traverse/Scope.js
+++ b/src/melody/melody-traverse/Scope.js
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Binding } from './Binding';
+import type Path from './Path';
+const CACHE_KEY = Symbol();
+let uid = 0;
+
+export default class Scope {
+    constructor(path: Path, parentScope?: Scope) {
+        this.uid = uid++;
+        this.parent = parentScope;
+
+        this.parentBlock = path.parent;
+        this.block = path.node;
+        this.path = path;
+
+        this.references = Object.create(null);
+        this.bindings = Object.create(null);
+        this.globals = Object.create(null);
+        this.uids = Object.create(null);
+        this.escapesContext = false;
+        this._contextName = null;
+        this.mutated = false;
+        //this.contextName = parentScope && parentScope.contextName || '_context';
+    }
+
+    set contextName(val) {
+        this._contextName = val;
+    }
+
+    get contextName() {
+        if (this._contextName) {
+            return this._contextName;
+        }
+        if (this.parent) {
+            return this.parent.contextName || '_context';
+        }
+        return '_context';
+    }
+
+    static get(path: Path, parentScope?: Scope) {
+        if (parentScope && parentScope.block == path.node) {
+            return parentScope;
+        }
+
+        const cached = getCache(path.node);
+        if (cached) {
+            return cached;
+        }
+
+        const scope = new Scope(path, parentScope);
+        path.node[CACHE_KEY] = scope;
+        return scope;
+    }
+
+    get needsSubContext() {
+        return this.escapesContext && this.hasCustomBindings;
+    }
+
+    get hasCustomBindings() {
+        return !!Object.keys(this.bindings).length;
+    }
+
+    getBinding(name: string) {
+        let scope = this;
+
+        do {
+            const binding = scope.getOwnBinding(name);
+            if (binding) {
+                return binding;
+            }
+            if (scope.path.is('RootScope')) {
+                return;
+            }
+        } while ((scope = scope.parent));
+    }
+
+    getOwnBinding(name: string) {
+        return this.bindings[name];
+    }
+
+    hasOwnBinding(name: string) {
+        return !!this.getOwnBinding(name);
+    }
+
+    hasBinding(name: string) {
+        return !name
+            ? false
+            : !!(this.hasOwnBinding(name) || this.parentHasBinding(name));
+    }
+
+    getRootScope() {
+        let scope = this;
+        while (scope.parent) {
+            scope = scope.parent;
+        }
+        return scope;
+    }
+
+    registerBinding(name: string, path: Path = null, kind: string = 'context') {
+        let scope = this;
+        if (kind === 'global' && path === null) {
+            scope = this.getRootScope();
+        } else if (kind === 'const') {
+            while (scope.parent) {
+                scope = scope.parent;
+                if (scope.path.is('RootScope')) {
+                    break;
+                }
+            }
+        }
+        // todo identify if we need to be able to differentiate between binding kinds
+        // if (scope.bindings[name]) {
+        // todo: warn about colliding binding or fix it
+        // }
+        if (this.path.state) {
+            this.path.state.markIdentifier(name);
+        }
+        return (scope.bindings[name] = new Binding(name, this, path, kind));
+    }
+
+    reference(name: string, path: Path) {
+        let binding = this.getBinding(name);
+        if (!binding) {
+            binding = this.registerBinding(name);
+        }
+        binding.reference(path);
+    }
+
+    parentHasBinding(name: string) {
+        return this.parent && this.parent.hasBinding(name);
+    }
+
+    generateUid(nameHint: string = 'temp') {
+        const name = toIdentifier(nameHint);
+
+        let uid,
+            i = 0;
+        do {
+            uid = generateUid(name, i);
+            i++;
+        } while (this.hasBinding(uid));
+
+        return uid;
+    }
+}
+
+function getCache(node) {
+    return node[CACHE_KEY];
+}
+
+function toIdentifier(nameHint) {
+    let name = nameHint + '';
+    name = name.replace(/[^a-zA-Z0-9$_]/g, '');
+
+    name = name.replace(/^[-0-9]+/, '');
+    name = name.replace(/[-\s]+(.)?/, function(match, c) {
+        return c ? c.toUpperCase() : '';
+    });
+
+    name = name.replace(/^_+/, '').replace(/[0-9]+$/, '');
+    return name;
+}
+
+function generateUid(name, i) {
+    if (i > 0) {
+        return `_${name}$${i}`;
+    }
+    return `_${name}`;
+}

--- a/src/melody/melody-traverse/TraversalContext.js
+++ b/src/melody/melody-traverse/TraversalContext.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Path from './Path';
+
+export default class TraversalContext {
+    constructor(scope, visitor, state, parentPath) {
+        this.parentPath = parentPath;
+        this.scope = scope;
+        this.state = state;
+        this.visitor = visitor;
+
+        this.queue = null;
+        this.priorityQueue = null;
+    }
+
+    create(parent, container, key, listKey): Path {
+        return Path.get({
+            parentPath: this.parentPath,
+            parent,
+            container,
+            key,
+            listKey,
+        });
+    }
+
+    shouldVisit(node): boolean {
+        const visitor = this.visitor;
+
+        if (visitor[node.type]) {
+            return true;
+        }
+
+        const keys: Array<String> = node.visitorKeys;
+        // this node doesn't have any children
+        if (!keys || !keys.length) {
+            return false;
+        }
+
+        let i, len;
+        for (i = 0, len = keys.length; i < len; i++) {
+            // check if some of its visitor keys have a value,
+            // if so, we need to visit it
+            if (node[keys[i]]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    visit(node, key) {
+        var nodes = node[key];
+        if (!nodes) {
+            return false;
+        }
+
+        if (Array.isArray(nodes)) {
+            return this.visitMultiple(nodes, node, key);
+        } else {
+            return this.visitSingle(node, key);
+        }
+    }
+
+    visitSingle(node, key): boolean {
+        if (this.shouldVisit(node[key])) {
+            return this.visitQueue([this.create(node, node, key)]);
+        } else {
+            return false;
+        }
+    }
+
+    visitMultiple(container, parent, listKey) {
+        if (!container.length) {
+            return false;
+        }
+
+        const queue = [];
+
+        for (let i = 0, len = container.length; i < len; i++) {
+            const node = container[i];
+            if (node && this.shouldVisit(node)) {
+                queue.push(this.create(parent, container, i, listKey));
+            }
+        }
+
+        return this.visitQueue(queue);
+    }
+
+    visitQueue(queue: Array<Path>) {
+        this.queue = queue;
+        this.priorityQueue = [];
+
+        let visited = [],
+            stop = false;
+
+        for (const path of queue) {
+            path.resync();
+            path.pushContext(this);
+
+            if (visited.indexOf(path.node) >= 0) {
+                continue;
+            }
+            visited.push(path.node);
+
+            if (path.visit()) {
+                stop = true;
+                break;
+            }
+
+            if (this.priorityQueue.length) {
+                stop = this.visitQueue(this.priorityQueue);
+                this.priorityQueue = [];
+                this.queue = queue;
+                if (stop) {
+                    break;
+                }
+            }
+        }
+
+        for (const path of queue) {
+            path.popContext();
+        }
+
+        this.queue = null;
+
+        return stop;
+    }
+
+    maybeQueue(path, notPriority?: boolean) {
+        if (this.queue) {
+            if (notPriority) {
+                this.queue.push(path);
+            } else {
+                this.priorityQueue.push(path);
+            }
+        }
+    }
+}

--- a/src/melody/melody-traverse/index.js
+++ b/src/melody/melody-traverse/index.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Path from './Path';
+import Scope from './Scope';
+export { Scope, Path };
+export * from './Scope';
+export { merge, explode } from './visitors';
+export { traverse, visit } from './traverse';

--- a/src/melody/melody-traverse/traverse.js
+++ b/src/melody/melody-traverse/traverse.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { explode } from './visitors';
+import TraversalContext from './TraversalContext';
+
+export function traverse(
+    parentNode,
+    visitor: Object,
+    scope?: Object,
+    state?: Object = {},
+    parentPath?: Object
+) {
+    if (!parentNode) {
+        return;
+    }
+
+    explode(visitor);
+    visit(parentNode, visitor, scope, state, parentPath);
+}
+
+export function visit(node, visitor, scope, state, parentPath) {
+    const keys: Array<String> = node.visitorKeys;
+    if (!keys || !keys.length) {
+        return;
+    }
+
+    const context = new TraversalContext(scope, visitor, state, parentPath);
+    for (let i = 0, len = keys.length; i < len; i++) {
+        const key = keys[i];
+        if (context.visit(node, key)) {
+            return;
+        }
+    }
+}

--- a/src/melody/melody-traverse/visitors.js
+++ b/src/melody/melody-traverse/visitors.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ALIAS_TO_TYPE } from 'melody-types';
+
+const EXPLODED = Symbol();
+
+export function explode(visitor) {
+    if (visitor[EXPLODED]) {
+        return visitor;
+    }
+    visitor[EXPLODED] = true;
+
+    for (const key of Object.getOwnPropertyNames(visitor)) {
+        // make sure all members are objects with enter and exit methods
+        let fns = visitor[key];
+        if (typeof fns === 'function') {
+            fns = visitor[key] = { enter: fns };
+        }
+
+        // make sure enter and exit are arrays
+        if (fns.enter && !Array.isArray(fns.enter)) {
+            fns.enter = [fns.enter];
+        }
+        if (fns.exit && !Array.isArray(fns.exit)) {
+            fns.exit = [fns.exit];
+        }
+    }
+
+    let j = 0;
+    const visitorKeys = Object.getOwnPropertyNames(visitor);
+    const visitorKeyLength = visitorKeys.length;
+    for (; j < visitorKeyLength; j++) {
+        const key = visitorKeys[j];
+        // manage aliases
+        if (ALIAS_TO_TYPE[key]) {
+            let i = 0;
+            for (
+                const types = ALIAS_TO_TYPE[key], len = types.length;
+                i < len;
+                i++
+            ) {
+                const type = types[i];
+                if (!visitor[type]) {
+                    visitor[type] = { enter: [] };
+                }
+                if (visitor[key].enter) {
+                    visitor[type].enter.push(...visitor[key].enter);
+                }
+                if (visitor[key].exit) {
+                    if (!visitor[type].exit) {
+                        visitor[type].exit = [];
+                    }
+                    visitor[type].exit.push(...visitor[key].exit);
+                }
+            }
+            delete visitor[key];
+        }
+    }
+}
+
+export function merge(...visitors: Array) {
+    const rootVisitor = {};
+
+    let i = 0;
+    for (const len = visitors.length; i < len; i++) {
+        const visitor = visitors[i];
+        explode(visitor);
+
+        let j = 0;
+        const visitorTypes = Object.getOwnPropertyNames(visitor);
+        for (
+            const numberOfTypes = visitorTypes.length;
+            j < numberOfTypes;
+            j++
+        ) {
+            const key = visitorTypes[j];
+            const visitorType = visitor[key];
+
+            if (!rootVisitor[key]) {
+                rootVisitor[key] = {};
+            }
+
+            const nodeVisitor = rootVisitor[key];
+            nodeVisitor.enter = [].concat(
+                nodeVisitor.enter || [],
+                visitorType.enter || []
+            );
+            nodeVisitor.exit = [].concat(
+                nodeVisitor.exit || [],
+                visitorType.exit || []
+            );
+        }
+    }
+
+    return rootVisitor;
+}

--- a/src/melody/melody-types/index.js
+++ b/src/melody/melody-types/index.js
@@ -1,0 +1,408 @@
+/**
+ * Copyright 2017 trivago N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as t from 'babel-types';
+
+export const TYPE_MAP = Object.create(null);
+export const ALIAS_TO_TYPE = Object.create(null);
+export const PATH_CACHE_KEY = Symbol();
+
+const IS_ALIAS_OF = Object.create(null);
+
+export class Node {
+    constructor() {
+        this.loc = {
+            source: null,
+            start: { line: 0, column: 0 },
+            end: { line: 0, column: 0 },
+        };
+        this[PATH_CACHE_KEY] = [];
+    }
+
+    toJSON() {
+        return Object.getOwnPropertyNames(this).reduce(
+            (acc, name) => {
+                if (name === 'loc' || name === 'parent') {
+                    return acc;
+                }
+                const value = this[name];
+                if (Array.isArray(value)) {
+                    acc[name] = value.map(val => val.toJSON());
+                } else {
+                    acc[name] = value && value.toJSON ? value.toJSON() : value;
+                }
+                return acc;
+            },
+            {
+                type: this.type,
+            }
+        );
+    }
+
+    static registerType(type) {
+        if (Node['is' + type]) {
+            return;
+        }
+
+        Node['is' + type] = function(node) {
+            return is(node, type);
+        };
+
+        // Node['assert' + type] = function(node) {
+        //   if (!is(node, type)) {
+        //     throw new Error('Expected node to be of type ' + type + ' but was ' + (node ? node.type : 'undefined') + ' instead');
+        //   }
+        // };
+    }
+}
+Node.registerType('Scope');
+
+export function is(node, type) {
+    if (!node) return false;
+
+    return (
+        node.type === type ||
+        (IS_ALIAS_OF[type] && IS_ALIAS_OF[type][node.type]) ||
+        t.is(type, node)
+    );
+}
+
+export function visitor(type, ...fields: String) {
+    type.prototype.visitorKeys = fields;
+}
+
+export function alias(type, ...aliases: String) {
+    type.prototype.aliases = aliases;
+    for (let i = 0, len = aliases.length; i < len; i++) {
+        const alias = aliases[i];
+        if (!ALIAS_TO_TYPE[alias]) {
+            ALIAS_TO_TYPE[alias] = [];
+        }
+        ALIAS_TO_TYPE[alias].push(type.prototype.type);
+        if (!IS_ALIAS_OF[alias]) {
+            IS_ALIAS_OF[alias] = {};
+        }
+        IS_ALIAS_OF[alias][type.prototype.type] = true;
+        Node.registerType(alias);
+    }
+}
+
+export function type(Type, type: String) {
+    Type.prototype.type = type;
+    TYPE_MAP[type] = Type;
+
+    Node.registerType(type);
+}
+
+export class Fragment extends Node {
+    constructor(expression: Node) {
+        super();
+        this.value = expression;
+    }
+}
+type(Fragment, 'Fragment');
+alias(Fragment, 'Statement');
+visitor(Fragment, 'value');
+
+export class PrintExpressionStatement extends Node {
+    constructor(expression: Node) {
+        super();
+        this.value = expression;
+    }
+}
+type(PrintExpressionStatement, 'PrintExpressionStatement');
+alias(PrintExpressionStatement, 'Statement', 'PrintStatement');
+visitor(PrintExpressionStatement, 'value');
+
+export class PrintTextStatement extends Node {
+    constructor(text: StringLiteral) {
+        super();
+        this.value = text;
+    }
+}
+type(PrintTextStatement, 'PrintTextStatement');
+alias(PrintTextStatement, 'Statement', 'PrintStatement');
+visitor(PrintTextStatement, 'value');
+
+export class ConstantValue extends Node {
+    constructor(value) {
+        super();
+        this.value = value;
+    }
+
+    toString() {
+        return `Const(${this.value})`;
+    }
+}
+type(ConstantValue, 'ConstantValue');
+alias(ConstantValue, 'Expression', 'Literal', 'Immutable');
+
+export class StringLiteral extends ConstantValue {}
+type(StringLiteral, 'StringLiteral');
+alias(StringLiteral, 'Expression', 'Literal', 'Immutable');
+
+export class NumericLiteral extends ConstantValue {}
+type(NumericLiteral, 'NumericLiteral');
+alias(NumericLiteral, 'Expression', 'Literal', 'Immutable');
+
+export class BooleanLiteral extends ConstantValue {
+    constructor(value) {
+        super(value);
+    }
+}
+type(BooleanLiteral, 'BooleanLiteral');
+alias(BooleanLiteral, 'Expression', 'Literal', 'Immutable');
+
+export class NullLiteral extends ConstantValue {
+    constructor() {
+        super(null);
+    }
+}
+type(NullLiteral, 'NullLiteral');
+alias(NullLiteral, 'Expression', 'Literal', 'Immutable');
+
+export class Identifier extends Node {
+    constructor(name) {
+        super();
+        this.name = name;
+    }
+}
+type(Identifier, 'Identifier');
+alias(Identifier, 'Expression');
+
+export class UnaryExpression extends Node {
+    constructor(operator: String, argument: Node) {
+        super();
+        this.operator = operator;
+        this.argument = argument;
+    }
+}
+type(UnaryExpression, 'UnaryExpression');
+alias(UnaryExpression, 'Expression', 'UnaryLike');
+visitor(UnaryExpression, 'argument');
+
+export class BinaryExpression extends Node {
+    constructor(operator: String, left: Node, right: Node) {
+        super();
+        this.operator = operator;
+        this.left = left;
+        this.right = right;
+    }
+}
+type(BinaryExpression, 'BinaryExpression');
+alias(BinaryExpression, 'Binary', 'Expression');
+visitor(BinaryExpression, 'left', 'right');
+
+export class BinaryConcatExpression extends BinaryExpression {
+    constructor(left: Node, right: Node) {
+        super('~', left, right);
+        this.wasImplicitConcatenation = false;
+    }
+}
+type(BinaryConcatExpression, 'BinaryConcatExpression');
+alias(BinaryConcatExpression, 'BinaryExpression', 'Binary', 'Expression');
+visitor(BinaryConcatExpression, 'left', 'right');
+
+export class ConditionalExpression extends Node {
+    constructor(test: Node, consequent: Node, alternate: Node) {
+        super();
+        this.test = test;
+        this.consequent = consequent;
+        this.alternate = alternate;
+    }
+}
+type(ConditionalExpression, 'ConditionalExpression');
+alias(ConditionalExpression, 'Expression', 'Conditional');
+visitor(ConditionalExpression, 'test', 'consequent', 'alternate');
+
+export class ArrayExpression extends Node {
+    constructor(elements = []) {
+        super();
+        this.elements = elements;
+    }
+}
+type(ArrayExpression, 'ArrayExpression');
+alias(ArrayExpression, 'Expression');
+visitor(ArrayExpression, 'elements');
+
+export class MemberExpression extends Node {
+    constructor(object: Node, property: Node, computed: boolean) {
+        super();
+        this.object = object;
+        this.property = property;
+        this.computed = computed;
+    }
+}
+type(MemberExpression, 'MemberExpression');
+alias(MemberExpression, 'Expression', 'LVal');
+visitor(MemberExpression, 'object', 'property');
+
+export class CallExpression extends Node {
+    constructor(callee: Node, args: Array<Node>) {
+        super();
+        this.callee = callee;
+        this.arguments = args;
+    }
+}
+type(CallExpression, 'CallExpression');
+alias(CallExpression, 'Expression', 'FunctionInvocation');
+visitor(CallExpression, 'callee', 'arguments');
+
+export class NamedArgumentExpression extends Node {
+    constructor(name: Identifier, value: Node) {
+        super();
+        this.name = name;
+        this.value = value;
+    }
+}
+type(NamedArgumentExpression, 'NamedArgumentExpression');
+alias(NamedArgumentExpression, 'Expression');
+visitor(NamedArgumentExpression, 'name', 'value');
+
+export class ObjectExpression extends Node {
+    constructor(properties: Array<ObjectProperty> = []) {
+        super();
+        this.properties = properties;
+    }
+}
+type(ObjectExpression, 'ObjectExpression');
+alias(ObjectExpression, 'Expression');
+visitor(ObjectExpression, 'properties');
+
+export class ObjectProperty extends Node {
+    constructor(key: Node, value: Node, computed: boolean) {
+        super();
+        this.key = key;
+        this.value = value;
+        this.computed = computed;
+    }
+}
+type(ObjectProperty, 'ObjectProperty');
+alias(ObjectProperty, 'Property', 'ObjectMember');
+visitor(ObjectProperty, 'key', 'value');
+
+export class SequenceExpression extends Node {
+    constructor(expressions: Array<Node> = []) {
+        super();
+        this.expressions = expressions;
+    }
+
+    add(child: Node) {
+        this.expressions.push(child);
+        this.loc.end = child.loc.end;
+    }
+}
+type(SequenceExpression, 'SequenceExpression');
+alias(SequenceExpression, 'Expression', 'Scope');
+visitor(SequenceExpression, 'expressions');
+
+export class SliceExpression extends Node {
+    constructor(target: Node, start: Node, end: Node) {
+        super();
+        this.target = target;
+        this.start = start;
+        this.end = end;
+    }
+}
+type(SliceExpression, 'SliceExpression');
+alias(SliceExpression, 'Expression');
+visitor(SliceExpression, 'source', 'start', 'end');
+
+export class FilterExpression extends Node {
+    constructor(target: Node, name: Identifier, args: Array<Node>) {
+        super();
+        this.target = target;
+        this.name = name;
+        this.arguments = args;
+    }
+}
+type(FilterExpression, 'FilterExpression');
+alias(FilterExpression, 'Expression');
+visitor(FilterExpression, 'target', 'arguments');
+
+export class Element extends Node {
+    constructor(name: String) {
+        super();
+        this.name = name;
+        this.attributes = [];
+        this.children = [];
+        this.selfClosing = false;
+    }
+}
+type(Element, 'Element');
+alias(Element, 'Expression');
+visitor(Element, 'attributes', 'children');
+
+export class Attribute extends Node {
+    constructor(name: Node, value: Node = null) {
+        super();
+        this.name = name;
+        this.value = value;
+    }
+
+    isImmutable() {
+        return is(this.name, 'Identifier') && is(this.value, 'Immutable');
+    }
+}
+type(Attribute, 'Attribute');
+visitor(Attribute, 'name', 'value');
+
+export class TwigComment extends Node {
+    constructor(text: StringLiteral) {
+        super();
+        this.value = text;
+    }
+}
+type(TwigComment, 'TwigComment');
+visitor(TwigComment, 'value');
+
+export class HtmlComment extends Node {
+    constructor(text: StringLiteral) {
+        super();
+        this.value = text;
+    }
+}
+type(HtmlComment, 'HtmlComment');
+visitor(HtmlComment, 'value');
+
+export class Declaration extends Node {
+    constructor(declarationType: String) {
+        super();
+        this.declarationType = declarationType;
+        this.parts = [];
+    }
+}
+type(Declaration, 'Declaration');
+visitor(Declaration, 'parts');
+
+export class GenericTwigTag extends Node {
+    constructor(tagName: String) {
+        super();
+        this.tagName = tagName;
+        this.parts = [];
+        this.sections = [];
+    }
+}
+type(GenericTwigTag, 'GenericTwigTag');
+
+export class GenericToken extends Node {
+    constructor(tokenType: String, tokenText: String) {
+        super();
+        this.tokenType = tokenType;
+        this.tokenText = tokenText;
+    }
+}
+type(GenericToken, 'GenericToken');


### PR DESCRIPTION
Related: GH-26, GH-32

This patch contains [trivago/melody](https://github.com/trivago/melody) that has been stripped down using `git-filter-repo`. This is an attempt to retain git history before applying GH-32.