### PR TITLE
Add support for arrow functions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,6 +18,7 @@ rules:
         - error
         - devDependencies: ["tests*/**", "scripts/**"]
     no-else-return: error
+    no-fallthrough: off
     no-inner-declarations: error
     no-unneeded-ternary: error
     no-debugger: off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+### Features
+- Add support for arrow function inside `filter, map, reduce` filter
+
 ### Internals
 - Optimize test runner by defining where to look for test files
 - NPM script alias to run `prettier` has been removed

--- a/src/melody/melody-parser/Lexer.js
+++ b/src/melody/melody-parser/Lexer.js
@@ -44,6 +44,7 @@ const CHAR_TO_TOKEN = {
     "|": TokenTypes.PIPE,
     ",": TokenTypes.COMMA,
     "?": TokenTypes.QUESTION_MARK,
+    "=>": TokenTypes.ARROW,
     "=": TokenTypes.ASSIGNMENT,
     //'<': TokenTypes.ELEMENT_START,
     //'>': TokenTypes.ELEMENT_END,
@@ -345,6 +346,13 @@ export default class Lexer {
                 this.pushState(State.STRING_DOUBLE);
                 input.next();
                 return this.createToken(TokenTypes.STRING_START, pos);
+            case "=":
+                // Lookahead for '>'
+                if (input.la(1) === ">") {
+                    input.next(); // Advance to '='
+                    input.next(); // Advance to '>'
+                    return this.createToken(TokenTypes.ARROW, pos);
+                }
             default: {
                 if (isDigit(input.lac(0))) {
                     input.next();

--- a/src/melody/melody-parser/TokenTypes.js
+++ b/src/melody/melody-parser/TokenTypes.js
@@ -44,6 +44,7 @@ export const COMMA = ",";
 export const DOT = ".";
 export const PIPE = "|";
 export const QUESTION_MARK = "?";
+export const ARROW = "=>";
 export const ASSIGNMENT = "=";
 export const ELEMENT_START = "<";
 export const SLASH = "/";

--- a/src/melody/melody-types/index.js
+++ b/src/melody/melody-types/index.js
@@ -323,6 +323,21 @@ type(NamedArgumentExpression, "NamedArgumentExpression");
 alias(NamedArgumentExpression, "Expression");
 visitor(NamedArgumentExpression, "name", "value");
 
+export class ArrowFunction extends Node {
+    /**
+     * @param {Array<Node>} args
+     * @param {Node} body
+     */
+    constructor(args, body) {
+        super();
+        this.args = args;
+        this.body = body;
+    }
+}
+type(ArrowFunction, "ArrowFunction");
+alias(ArrowFunction, "Expression");
+visitor(ArrowFunction, "args", "body");
+
 export class ObjectExpression extends Node {
     /**
      * @param {Array<ObjectProperty>} properties

--- a/src/print/ArrowFunction.js
+++ b/src/print/ArrowFunction.js
@@ -1,0 +1,37 @@
+import { doc } from "prettier";
+const { group, indent, join, line, softline } = doc.builders;
+
+const p = (node, path, print) => {
+    const args = node.args;
+    const body = path.call(print, "body");
+
+    const parts = [];
+
+    // Args
+    if (args.length > 1) {
+        // Multiple args
+        parts.push(
+            group([
+                "(",
+                join(
+                    ", ",
+                    args.map(arg => arg.name)
+                ),
+                ")"
+            ])
+        );
+    } else {
+        // Single arg
+        parts.push(args[0].name);
+    }
+
+    // Arrow
+    parts.push(" => ");
+
+    // Body
+    parts.push(body);
+
+    return group(parts);
+};
+
+export { p as printArrowFunction };

--- a/src/printer.js
+++ b/src/printer.js
@@ -7,6 +7,7 @@ import { printIdentifier } from "./print/Identifier.js";
 import { printExpressionStatement } from "./print/ExpressionStatement.js";
 import { printMemberExpression } from "./print/MemberExpression.js";
 import { printFilterExpression } from "./print/FilterExpression.js";
+import { printArrowFunction } from "./print/ArrowFunction.js";
 import { printObjectExpression } from "./print/ObjectExpression.js";
 import { printObjectProperty } from "./print/ObjectProperty.js";
 import { printCallExpression } from "./print/CallExpression.js";
@@ -194,6 +195,7 @@ printFunctions["PrintTextStatement"] = printTextStatement;
 printFunctions["PrintExpressionStatement"] = printExpressionStatement;
 printFunctions["MemberExpression"] = printMemberExpression;
 printFunctions["FilterExpression"] = printFilterExpression;
+printFunctions["ArrowFunction"] = printArrowFunction;
 printFunctions["ObjectExpression"] = printObjectExpression;
 printFunctions["ObjectProperty"] = printObjectProperty;
 

--- a/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
@@ -42,6 +42,27 @@ exports[`arrayExpression.twig - twig-verify > arrayExpression.twig 1`] = `
 
 `;
 
+exports[`arrowFunctions.twig - twig-verify > arrowFunctions.twig 1`] = `
+Arrow function with one argument:
+{{ someArray|filter(item => item.amount > 5) }}
+
+Arrow function with multiple arguments:
+{{ someArray|map((value, key) => "key #{key} with value #{value}") }}
+
+Arrow function with multiple arguments and second filter argument:
+{{ numbers|reduce((carry, v, k) => carry + v * k, 10) }}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Arrow function with one argument:
+{{ someArray|filter(item => item.amount > 5) }}
+
+Arrow function with multiple arguments:
+{{ someArray|map((value, key) => "key #{key} with value #{value}") }}
+
+Arrow function with multiple arguments and second filter argument:
+{{ numbers|reduce((carry, v, k) => carry + v * k, 10) }}
+
+`;
+
 exports[`binaryExpressions.twig - twig-verify > binaryExpressions.twig 1`] = `
 {% set highlightValueForMoney = isFeatureEnabled('vFMV5') or isCTestActive('WEB-48935') or isCTestActive('WEB-48956') or isCTestActive('WEB-48955')%}
 

--- a/tests/Expressions/arrowFunctions.twig
+++ b/tests/Expressions/arrowFunctions.twig
@@ -1,0 +1,8 @@
+Arrow function with one argument:
+{{ someArray|filter(item => item.amount > 5) }}
+
+Arrow function with multiple arguments:
+{{ someArray|map((value, key) => "key #{key} with value #{value}") }}
+
+Arrow function with multiple arguments and second filter argument:
+{{ numbers|reduce((carry, v, k) => carry + v * k, 10) }}


### PR DESCRIPTION
Adds support for arrow functions inside filters, which makes formatting `|filter()`, `|map()` and `|reduce()` filters possible, resolving  #19.

Includes a new test file for three scenarios:
* Arrow function with one argument: 
```twig
{{ someArray|filter(item => item.amount > 5) }}
```
* Arrow function with multiple arguments:
```twig
{{ someArray|map((value, key) => "key #{key} with value #{value}") }}
```
* Arrow function with multiple arguments and second filter argument:
```twig
{{ numbers|reduce((carry, v, k) => carry + v * k, 10) }}
```

I also tested with a variety of other combinations, including named parameters, which all seem to work. I will post my notes in the corresponding issue, in case someone is interested.