### PR TITLE
Optimize test files lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+### Internals
+- Optimize test runner by defining where to look for test files
+
 ---
 ## 0.7.0 (2024-08-01)
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
         }
     },
     test: {
+        dir: "tests",
         setupFiles: ["./tests_config/run_spec.js"],
         snapshotSerializers: ["./tests_config/raw-serializer.js"],
         testRegex: "jsfmt\\.spec\\.js$|__tests__/.*\\.js$"


### PR DESCRIPTION
If you use nix flakes and enabling it using direnv, there will be `.devenv` and `.direnv` directories in your root project directory. By default vitest will try to look for test files in all directories unless it is being excluded. Unfortunately `.devenv` and `.direnv` is not on that list.

All we need is just tell vitest only to look for in `tests` directory.