### PR TITLE
Remove npm script alias to run prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Internals
 - Optimize test runner by defining where to look for test files
+- NPM script alias to run `prettier` has been removed
 
 ---
 ## 0.7.0 (2024-08-01)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     ],
     "scripts": {
         "lint": "DEBUG=eslint:cli-engine eslint .",
-        "prettier": "prettier --plugin=./src/index.js --parser=twig",
         "test": "vitest --run"
     },
     "dependencies": {


### PR DESCRIPTION
I don't see the value of having this npm script alias. Having this script alias make it difficult to format our codebase. Instead of `yarn prettier --write filename.js` we need to run
`./node_modules/.bin/prettier --write filename.js` which more verbose.