### PR TITLE
Feature: Add support for spread operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ __Example__
 +       printWidth: 120
 ```
 
+### Features
+- Add support for spread operator
+
+__Example__
+```twig
+<twig:Component {{ ...vars }} />
+
+{% set numbers = [1, 2, ...moreNumbers] %}
+{% set ratings = {'q1': 10, 'q2': 5, ...moreRatings} %}
+
+{{ 'Hello %s %s!'|format(...['Fabien', 'Potencier']) }}
+```
 ---
 ## 0.11.1 (2024-11-13)
 

--- a/src/melody/melody-extension-core/operators.js
+++ b/src/melody/melody-extension-core/operators.js
@@ -38,6 +38,13 @@ export const binaryOperators = [];
 export const tests = [];
 
 //region Unary Expressions
+export const SpreadExpression = createUnaryOperator(
+    "...",
+    "SpreadExpression",
+    // I can't find precedence reference for spread operator
+    // Ref: https://twig.symfony.com/doc/3.x/templates.html#operators
+    20
+);
 export const UnaryNotExpression = createUnaryOperator(
     "not",
     "UnaryNotExpression",

--- a/tests/Expressions/__snapshots__/spread_operator.snap.twig
+++ b/tests/Expressions/__snapshots__/spread_operator.snap.twig
@@ -1,0 +1,17 @@
+Some variation of spread operator
+
+{{ ...some_var }}
+<twig:Component {{ ...vars }} />
+
+{% set numbers = [1, 2, ...moreNumbers] %}
+{% set ratings = {
+    q1: 10,
+    ...options,
+    q2: 5,
+    ...moreRatings,
+    q3,
+    option: '',
+    'other-option'
+} %}
+
+{{ 'Hello %s %s!'|format(...['Fabien', 'Potencier']) }}

--- a/tests/Expressions/jsfmt.spec.js
+++ b/tests/Expressions/jsfmt.spec.js
@@ -62,6 +62,17 @@ describe("Expressions", () => {
         });
         await expect(actual).toMatchFileSnapshot(snapshotFile);
     });
+
+    it("should handle spread operators", async () => {
+        const { actual, snapshotFile } = await run_spec(import.meta.url, {
+            source: "spread_operator.twig",
+            formatOptions: {
+                twigAlwaysBreakObjects: false
+            }
+        });
+        await expect(actual).toMatchFileSnapshot(snapshotFile);
+    });
+
     it("should handle string concatenation", async () => {
         const { actual, snapshotFile } = await run_spec(import.meta.url, {
             source: "stringConcat.twig"

--- a/tests/Expressions/spread_operator.twig
+++ b/tests/Expressions/spread_operator.twig
@@ -1,0 +1,9 @@
+Some variation of spread operator
+
+{{ ...some_var }}
+<twig:Component {{ ...vars }} />
+
+{% set numbers = [1, 2, ...moreNumbers] %}
+{% set ratings = {'q1': 10, ...options, 'q2': 5, ...moreRatings, q3, 'option':'','other-option'} %}
+
+{{ 'Hello %s %s!'|format(...['Fabien', 'Potencier']) }}


### PR DESCRIPTION
Close GH-44.

Partially depends on GH-16.

Need help on how to parse this expression
```shell
Error: Error: ERROR: Invalid map key
  32 | <twig:Component {{ ...vars }} />
  33 | {% set numbers = [1, 2, ...moreNumbers] %}
> 34 | {% set ratings = {'foo': 10, 'bar': 5, ...moreRatings} %}
     |                                        ^
  35 | 
```