### PR TITLE
Documentation: Fix actual default value of `twigAlwaysBreakObjects` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 - Fix handling mapping that omit key part
+- Fix documentation about `twigAlwaysBreakObjects` option to reflect actual default value
 
 ---
 ## 0.8.0 (2024-08-09)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Values can be `true` or `false`. If `true`, single quotes will be used for strin
 
 Because Twig files might have a lot of nesting, it can be useful to define a separate print width for Twig files. This can be done with this option. If it is not set, the standard `printWidth` option is used.
 
-### twigAlwaysBreakObjects (default: `false`)
+### twigAlwaysBreakObjects (default: `true`)
 
 If set to `true`, objects will always be wrapped/broken, even if they would fit on one line:
 


### PR DESCRIPTION
Close GH-56.