### PR TITLE
Bugfix: lodash named import is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Bugfixes
+- Fix importing lodash function syntax
+- Fix import template function from `@babel/template`
+
 ---
 ## 0.9.0 (2024-10-03)
 

--- a/src/melody/melody-extension-core/visitors/filters.js
+++ b/src/melody/melody-extension-core/visitors/filters.js
@@ -14,7 +14,22 @@
  * limitations under the License.
  */
 import * as t from "@babel/types";
-import template from "@babel/template";
+import isFunction from "lodash/isFunction.js";
+import _template from "@babel/template";
+
+/**
+ * For some reason there's inconsistency when importing "@babel/template" on
+ * vitest environment and loading this plugin directly on cli. I have no idea why
+ * this happens but this workaround seems to be fixed it.
+ *
+ * Without this workaround, an error will occur either on test or when loading
+ * plugin on cli. This error doesn't happen on `src/melody/melody-extension-core/visitors/for.js`.
+ * ```
+ * [error] template is not a function
+ * ```
+ */
+const template = isFunction(_template) ? _template : _template.default;
+
 // use default value if var is null, undefined or an empty string
 // but use var if value is 0, false, an empty array or an empty object
 const defaultFilter = template("VAR != null && VAR !== '' ? VAR : DEFAULT");

--- a/src/print/AutoescapeBlock.js
+++ b/src/print/AutoescapeBlock.js
@@ -1,5 +1,5 @@
 import { doc } from "prettier";
-import { isBoolean } from "lodash";
+import isBoolean from "lodash/isBoolean.js";
 import { printChildBlock, quoteChar } from "../util/index.js";
 
 const { hardline } = doc.builders;


### PR DESCRIPTION
Close GH-66

This patch also contains fix to use template function from `@babel/template` that for some reason behave differently between test environment and loading directly on prettier cli.