### PR TITLE
Feature: Support for colon as separators between argument names and values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - Add support for default value on macros
 - Add support for test expression `instance of`, feature of [Craft CMS](https://craftcms.com/docs/5.x/reference/twig/tests.html#instance-of)
+- Add support for colon as separators between argument names and values
 
 ### Internals
 - Test with Node.js 22, current active lts version

--- a/src/melody/melody-parser/Parser.js
+++ b/src/melody/melody-parser/Parser.js
@@ -950,7 +950,8 @@ export default class Parser {
                 args.push(arrowFunction);
             } else if (
                 tokens.test(Types.SYMBOL) &&
-                tokens.lat(1) === Types.ASSIGNMENT
+                (tokens.lat(1) === Types.ASSIGNMENT ||
+                    tokens.lat(1) === Types.COLON)
             ) {
                 // OPTION 2: named filter argument(s)
                 const name = tokens.next();

--- a/tests/Expressions/__snapshots__/callExpression.snap.twig
+++ b/tests/Expressions/__snapshots__/callExpression.snap.twig
@@ -2,6 +2,10 @@
 
 {{ date('d/m/Y H:i', timezone = 'Europe/Paris') }}
 
+{# Colon as separator for named argument, require twig 3.12 or later #}
+{# Ref: https://github.com/zackad/prettier-plugin-twig/issues/74 #}
+{{ date('d/m/Y H:i', timezone = 'Europe/Paris') }}
+
 <span class="{{ css.partner }}">
     <div>
         <div>

--- a/tests/Expressions/callExpression.twig
+++ b/tests/Expressions/callExpression.twig
@@ -2,6 +2,10 @@
 
 {{ date('d/m/Y H:i', timezone="Europe/Paris") }}
 
+{# Colon as separator for named argument, require twig 3.12 or later #}
+{# Ref: https://github.com/zackad/prettier-plugin-twig/issues/74 #}
+{{ date('d/m/Y H:i', timezone:"Europe/Paris") }}
+
 <span class="{{ css.partner }}">
     <div>
         <div>


### PR DESCRIPTION
Close GH-74

Ref: https://twig.symfony.com/doc/3.x/templates.html#named-arguments