### PR TITLE
Feature: Update twig coding standards to follow version 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## unreleased
 
+> [!IMPORTANT]
+> Twig coding standard has been updated to version 3.x. This contains BREAKING CHANGES.
+
+### BREAKING CHANGES
+This release contains breaking changes, check your setup before upgrading.
+Option `twigFollowOfficialCodingStandards` is set to `true` by default. If you're
+using twig version _3.11_ or older it will break your setup. Notable changes on
+twig coding standard on version 3.x is added support for using colon `:` as separator
+for argument names and values (which is enabled by default with this plugin).
+
+__Example__
+```twig
+{# Input #}
+{{ data|convert_encoding(from= 'iso-2022-jp', to: 'UTF-8') }}
+
+{# Before #}
+{{ data|convert_encoding(from = 'iso-2022-jp', to = 'UTF-8') }}
+
+{# After #}
+{{ data|convert_encoding(from: 'iso-2022-jp', to: 'UTF-8') }}
+```
+
+__What to do?__
+- If you want to upgrade this plugin, make sure that you're using twig version 3.12 or later
+- If you want to keep using older version of twig, you can set option `twigFollowOfficialCodingStandards` to false (your code style might become inconsistent)
+
+### Features
+- BREAKING CHANGES: Update twig coding standard to follow version 3.x
+
 ---
 ## 0.10.0 (2024-11-11)
 

--- a/src/print/NamedArgumentExpression.js
+++ b/src/print/NamedArgumentExpression.js
@@ -1,10 +1,11 @@
 import { STRING_NEEDS_QUOTES } from "../util/index.js";
 
-const p = (node, path, print) => {
+const p = (node, path, print, options) => {
     node[STRING_NEEDS_QUOTES] = true;
     const printedName = path.call(print, "name");
     const printedValue = path.call(print, "value");
-    return [printedName, " = ", printedValue];
+    const separator = options.twigFollowOfficialCodingStandards ? ": " : " = ";
+    return [printedName, separator, printedValue];
 };
 
 export { p as printNamedArgumentExpression };

--- a/tests/Expressions/__snapshots__/callExpression.snap.twig
+++ b/tests/Expressions/__snapshots__/callExpression.snap.twig
@@ -1,10 +1,10 @@
 {{ range(3) }}
 
-{{ date('d/m/Y H:i', timezone = 'Europe/Paris') }}
+{{ date('d/m/Y H:i', timezone: 'Europe/Paris') }}
 
 {# Colon as separator for named argument, require twig 3.12 or later #}
 {# Ref: https://github.com/zackad/prettier-plugin-twig/issues/74 #}
-{{ date('d/m/Y H:i', timezone = 'Europe/Paris') }}
+{{ date('d/m/Y H:i', timezone: 'Europe/Paris') }}
 
 <span class="{{ css.partner }}">
     <div>

--- a/tests/TwigCodingStandards/__snapshots__/disable_twig_coding_standards.snap.twig
+++ b/tests/TwigCodingStandards/__snapshots__/disable_twig_coding_standards.snap.twig
@@ -1,0 +1,37 @@
+{{ foo }}
+{# comment #}
+{% if foo %}{% endif %}
+
+{{- foo -}}
+{#- comment -#}
+{%- if foo -%}{%- endif -%}
+
+{{ 1 + 2 }}
+{{ foo ~ bar }}
+{{ true ? true : false }}
+
+{{ [1, 2, 3] }}
+{{
+    {
+        foo: 'bar'
+    }
+}}
+
+{{ 1 + 2 * 3 }}
+
+{{ foo | upper | lower }}
+{{ user.name }}
+{{ user[name] }}
+{% for i in 1..12 %}{% endfor %}
+
+{{ foo | default('foo') }}
+{{ range(1..10) }}
+
+{% block foo %}
+    {% if true %}
+        true
+    {% endif %}
+{% endblock %}
+
+{# Introduced in twig version 3.12 #}
+{{ data | convert_encoding(from = 'iso-2022-jp', to = 'UTF-8') }}

--- a/tests/TwigCodingStandards/__snapshots__/enable_twig_coding_standards.snap.twig
+++ b/tests/TwigCodingStandards/__snapshots__/enable_twig_coding_standards.snap.twig
@@ -1,0 +1,37 @@
+{{ foo }}
+{# comment #}
+{% if foo %}{% endif %}
+
+{{- foo -}}
+{#- comment -#}
+{%- if foo -%}{%- endif -%}
+
+{{ 1 + 2 }}
+{{ foo ~ bar }}
+{{ true ? true : false }}
+
+{{ [1, 2, 3] }}
+{{
+    {
+        foo: 'bar'
+    }
+}}
+
+{{ 1 + 2 * 3 }}
+
+{{ foo|upper|lower }}
+{{ user.name }}
+{{ user[name] }}
+{% for i in 1..12 %}{% endfor %}
+
+{{ foo|default('foo') }}
+{{ range(1..10) }}
+
+{% block foo %}
+    {% if true %}
+        true
+    {% endif %}
+{% endblock %}
+
+{# Introduced in twig version 3.12 #}
+{{ data|convert_encoding(from: 'iso-2022-jp', to: 'UTF-8') }}

--- a/tests/TwigCodingStandards/disable_twig_coding_standards.twig
+++ b/tests/TwigCodingStandards/disable_twig_coding_standards.twig
@@ -28,3 +28,6 @@
         true
     {% endif %}
 {% endblock %}
+
+{# Introduced in twig version 3.12 #}
+{{ data|convert_encoding(from: 'iso-2022-jp', to= 'UTF-8') }}

--- a/tests/TwigCodingStandards/enable_twig_coding_standards.twig
+++ b/tests/TwigCodingStandards/enable_twig_coding_standards.twig
@@ -11,13 +11,9 @@
 {{ true ? true : false }}
 
 {{ [1, 2, 3] }}
-{{
-    {
-        foo: 'bar'
-    }
-}}
+{{ {'foo': 'bar'} }}
 
-{{ 1 + 2 * 3 }}
+{{ 1 + (2 * 3) }}
 
 {{ foo|upper|lower }}
 {{ user.name }}
@@ -28,7 +24,10 @@
 {{ range(1..10) }}
 
 {% block foo %}
-    {% if true %}
-        true
-    {% endif %}
+  {% if true %}
+    true
+  {% endif %}
 {% endblock %}
+
+{# Introduced in twig version 3.12 #}
+{{ data|convert_encoding(from: 'iso-2022-jp', to= 'UTF-8') }}

--- a/tests/TwigCodingStandards/jsfmt.spec.js
+++ b/tests/TwigCodingStandards/jsfmt.spec.js
@@ -1,15 +1,23 @@
 import { run_spec } from "tests_config/run_spec";
 import { describe, expect, it } from "vitest";
 
-/** @type {import('tests_config/run_spec').PrettierOptions} */
-const formatOptions = {
-    twigAlwaysBreakObjects: false
-};
-
 describe("Twig coding standards", () => {
-    it("should follow twig coding standards", async () => {
+    it("disable follow twig coding standards", async () => {
         const { actual, snapshotFile } = await run_spec(import.meta.url, {
-            source: "twigCodingStandards.twig"
+            source: "disable_twig_coding_standards.twig",
+            formatOptions: {
+                twigFollowOfficialCodingStandards: false
+            }
+        });
+        await expect(actual).toMatchFileSnapshot(snapshotFile);
+    });
+
+    it("enable follow twig coding standards", async () => {
+        const { actual, snapshotFile } = await run_spec(import.meta.url, {
+            source: "enable_twig_coding_standards.twig",
+            formatOptions: {
+                twigFollowOfficialCodingStandards: true
+            }
         });
         await expect(actual).toMatchFileSnapshot(snapshotFile);
     });

--- a/tests/smoke-test.twig
+++ b/tests/smoke-test.twig
@@ -25,6 +25,6 @@
         {% set map = {
             city: 'Paris'
         } %}
-        {{ data|convert_encoding(from = 'iso-2022-jp', to = 'UTF-8') }}
+        {{ data|convert_encoding(from: 'iso-2022-jp', to: 'UTF-8') }}
     </body>
 </html>


### PR DESCRIPTION
Close GH-71

BREAKING CHANGES:
- Make sure to update twig to version 3.12 or later
- Separator between argument names and values has been changed from ` = ` into `: ` for named arguments