### PR TITLE
Feature: Remove option `twigPrintWidth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## unreleased
 
+> [!IMPORTANT]
+> Yet another breaking changes. See release notes or changelog before upgrading.
+
+### BREAKING CHANGES
+- Option `twigPrintWidth` has been removed
+
+I don't see any reason why we should keep the option `twigPrintWidth`. Prettier provide mechanism to use different `printWidth` for different file types by using _override_ (see example below).
+
+__What to do?__
+
+Remove `twigPrintWidth` from your prettier config and use [override](https://prettier.io/docs/en/configuration.html#configuration-overrides) instead.
+
+__Example__
+```diff
+  # ./.prettierrc.yaml
+- twigPrintWidth: 120
++ overrides:
++   - files: "*.twig"
++     options:
++       printWidth: 120
+```
+
 ---
 ## 0.11.1 (2024-11-13)
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ This Prettier plugin comes with some options that you can add to your Prettier c
 
 Values can be `true` or `false`. If `true`, single quotes will be used for string literals in Twig files.
 
-### twigPrintWidth (default: `80`)
-
-Because Twig files might have a lot of nesting, it can be useful to define a separate print width for Twig files. This can be done with this option. If it is not set, the standard `printWidth` option is used.
-
 ### twigAlwaysBreakObjects (default: `true`)
 
 If set to `true`, objects will always be wrapped/broken, even if they would fit on one line:

--- a/src/index.js
+++ b/src/index.js
@@ -91,12 +91,6 @@ const options = {
         default: true,
         description: "Should objects always break in Twig files?"
     },
-    twigPrintWidth: {
-        type: "int",
-        category: "Global",
-        default: 80,
-        description: "Print width for Twig files"
-    },
     twigFollowOfficialCodingStandards: {
         type: "boolean",
         category: "Global",

--- a/src/printer.js
+++ b/src/printer.js
@@ -97,10 +97,6 @@ const print = (path, options, print) => {
         originalSource = node[ORIGINAL_SOURCE];
     }
 
-    if (options.twigPrintWidth) {
-        options.printWidth = options.twigPrintWidth;
-    }
-
     checkForIgnoreEnd(node);
     const useOriginalSource =
         (shouldApplyIgnoreNext(node) && ignoreNext) || ignoreRegion;

--- a/tests/Failing/jsfmt.spec.js
+++ b/tests/Failing/jsfmt.spec.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 /** @type {import('tests_config/run_spec').PrettierOptions} */
 const formatOptions = {
-    twigPrintWidth: 120,
+    printWidth: 120,
     twigAlwaysBreakObjects: true,
     twigFollowOfficialCodingStandards: false
 };

--- a/tests/Options/jsfmt.spec.js
+++ b/tests/Options/jsfmt.spec.js
@@ -24,7 +24,7 @@ describe("Options", () => {
         const { actual, snapshotFile } = await run_spec(import.meta.url, {
             source: "printWidth.twig",
             formatOptions: {
-                twigPrintWidth: 120
+                printWidth: 120
             }
         });
         await expect(actual).toMatchFileSnapshot(snapshotFile);


### PR DESCRIPTION
Related GH-50.

## BREAKING CHANGES
- Option `twigPrintWidth` has been removed

I don't see any reason why we should keep the option `twigPrintWidth`. Prettier provide mechanism to use different `printWidth` for different file types by using _override_ (see example below).

__What to do?__

Remove `twigPrintWidth` from your prettier config and use [override](https://prettier.io/docs/en/configuration.html#configuration-overrides) instead.

__Example__
```diff
  # ./.prettierrc.yaml
- twigPrintWidth: 120
+ overrides:
+   - files: "*.twig"
+     options:
+       printWidth: 120
```

