### PR TITLE
Bugfix: Make sure that empty block will have empty line in between

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ __Example__
 
 {{ 'Hello %s %s!'|format(...['Fabien', 'Potencier']) }}
 ```
+
+### Bugfixes
+- Make sure that empty block statement will have empty line in between for consistency
+
 ---
 ## 0.11.1 (2024-11-13)
 

--- a/src/print/BlockStatement.js
+++ b/src/print/BlockStatement.js
@@ -18,6 +18,11 @@ const p = (node, path, print, options) => {
             node.trimRightBlock ? " -%}" : " %}"
         ];
         const parts = [opener];
+
+        if (node.body.length === 0) {
+            parts.push(hardline);
+        }
+
         if (node.body.length > 0) {
             const indentedBody = printChildBlock(node, path, print, "body");
             parts.push(indentedBody);
@@ -30,10 +35,9 @@ const p = (node, path, print, options) => {
             node.trimRight ? " -%}" : " %}"
         );
 
-        const result = group(parts);
-        return result;
+        return group(parts);
     } else if (Node.isPrintExpressionStatement(node.body)) {
-        const parts = [
+        return [
             node.trimLeft ? "{%-" : "{%",
             " block ",
             path.call(print, "name"),
@@ -41,7 +45,6 @@ const p = (node, path, print, options) => {
             path.call(print, "body", "value"),
             node.trimRight ? " -%}" : " %}"
         ];
-        return parts;
     }
 };
 

--- a/tests/IncludeEmbed/__snapshots__/block.snap.twig
+++ b/tests/IncludeEmbed/__snapshots__/block.snap.twig
@@ -10,7 +10,20 @@
 
 {{ block('hello') }}
 
-{% block content %}
+{% block content_empty %}
+
+{% endblock %}
+
+{% block content_noline %}
+
+{% endblock %}
+
+{% block content_multiline %}
+
+{% endblock %}
+
+{% block content_empty_indented %}
+
 {% endblock %}
 
 {%- block hello -%}

--- a/tests/IncludeEmbed/block.twig
+++ b/tests/IncludeEmbed/block.twig
@@ -10,7 +10,21 @@
 
 {{ block('hello') }}
 
-{% block content %}{% endblock %}
+{% block content_empty %}{% endblock %}
+
+{% block content_noline %}
+{% endblock %}
+
+{% block content_multiline %}
+
+
+
+
+
+{% endblock %}
+
+    {% block content_empty_indented %}
+    {% endblock %}
 
 {%- block hello -%}
     Hello


### PR DESCRIPTION
Close GH-84

Example:
```twig
{% block content %}{% endblock %}
```

Will be printed as:
```twig
{% block content %}

{% endblock %}
```