### PR TITLE
Chore: Add package.json as exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
     "license": "Apache-2.0",
     "author": "Tom Bartel <thomas.bartel@trivago.com>",
     "type": "module",
-    "exports": "./src/index.js",
+    "exports": {
+        ".": {
+            "default": "./src/index.js"
+        },
+        "./package.json": "./package.json"
+    },
     "files": [
         "src"
     ],


### PR DESCRIPTION
This will allow downstream package to access this plugin metadata.