### PR TITLE
Bugfix: Handle string literal body when using block shortcut syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ __bracketSameLine: `false`__
 <br />
 ```
 
+- GH-106 Fix handling string literal when using block shortcut syntax
+
 ### Internals
 - Add option to add prefix/suffix for test snapshot output. This will allow to reuse single input file to produce several snapshot output with different configuration
 

--- a/src/print/BlockStatement.js
+++ b/src/print/BlockStatement.js
@@ -1,6 +1,10 @@
 import { doc } from "prettier";
-import { Node } from "../melody/melody-types/index.js";
-import { EXPRESSION_NEEDED, printChildBlock } from "../util/index.js";
+import { Node, StringLiteral } from "../melody/melody-types/index.js";
+import {
+    printChildBlock,
+    EXPRESSION_NEEDED,
+    STRING_NEEDS_QUOTES
+} from "../util/index.js";
 
 const { hardline, group } = doc.builders;
 
@@ -37,6 +41,9 @@ const p = (node, path, print, options) => {
 
         return group(parts);
     } else if (Node.isPrintExpressionStatement(node.body)) {
+        if (node.body.value instanceof StringLiteral) {
+            node[STRING_NEEDS_QUOTES] = true;
+        }
         return [
             node.trimLeft ? "{%-" : "{%",
             " block ",

--- a/tests/IncludeEmbed/__snapshots__/block_shortcut.snap.twig
+++ b/tests/IncludeEmbed/__snapshots__/block_shortcut.snap.twig
@@ -1,0 +1,9 @@
+{% block title %}
+    {{ page_title|title }}
+{% endblock %}
+
+{% block title page_title|title %}
+
+{% block title 'page_title' %}
+
+{% block empty_value '' %}

--- a/tests/IncludeEmbed/block_shortcut.twig
+++ b/tests/IncludeEmbed/block_shortcut.twig
@@ -1,0 +1,13 @@
+{% block title %}
+        {{ page_title|title }}
+
+{% endblock %}
+
+{% block title   page_title|title %}
+
+{% block title 'page_title'
+
+%}
+
+{%
+    block    empty_value '' %}

--- a/tests/IncludeEmbed/jsfmt.spec.js
+++ b/tests/IncludeEmbed/jsfmt.spec.js
@@ -13,6 +13,12 @@ describe("Include embed", () => {
         });
         await expect(actual).toMatchFileSnapshot(snapshotFile);
     });
+    it("should handle block shortcut", async () => {
+        const { actual, snapshotFile } = await run_spec(import.meta.url, {
+            source: "block_shortcut.twig"
+        });
+        await expect(actual).toMatchFileSnapshot(snapshotFile);
+    });
     it("should handle embed", async () => {
         const { actual, snapshotFile } = await run_spec(import.meta.url, {
             source: "embed.twig"


### PR DESCRIPTION
Close GH-106