### PR TITLE
Refactor: Don't use alias to export print function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+### Internals
+- DX: Don't use alias to export print function to make it easier to identify when debugging call stack
+
 ---
 ## 0.14.0 (2024-12-18)
 

--- a/src/print/AliasExpression.js
+++ b/src/print/AliasExpression.js
@@ -1,5 +1,5 @@
-const p = (node, path, print) => {
+const printAliasExpression = (node, path, print) => {
     return [path.call(print, "name"), " as ", path.call(print, "alias")];
 };
 
-export { p as printAliasExpression };
+export { printAliasExpression };

--- a/src/print/ArrayExpression.js
+++ b/src/print/ArrayExpression.js
@@ -3,7 +3,7 @@ import { STRING_NEEDS_QUOTES } from "../util/index.js";
 
 const { group, softline, line, indent, join } = doc.builders;
 
-const p = (node, path, print) => {
+const printArrayExpression = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     const mappedElements = path.map(print, "elements");
     const indentedContent = [softline, join([",", line], mappedElements)];
@@ -11,4 +11,4 @@ const p = (node, path, print) => {
     return group(["[", indent(indentedContent), softline, "]"]);
 };
 
-export { p as printArrayExpression };
+export { printArrayExpression };

--- a/src/print/ArrowFunction.js
+++ b/src/print/ArrowFunction.js
@@ -1,7 +1,7 @@
 import { doc } from "prettier";
 const { group, indent, join, line, softline } = doc.builders;
 
-const p = (node, path, print) => {
+const printArrowFunction = (node, path, print) => {
     const args = node.args;
     const body = path.call(print, "body");
 
@@ -34,4 +34,4 @@ const p = (node, path, print) => {
     return group(parts);
 };
 
-export { p as printArrowFunction };
+export { printArrowFunction };

--- a/src/print/Attribute.js
+++ b/src/print/Attribute.js
@@ -19,7 +19,7 @@ const printConcatenatedString = (valueNode, path, print, ...initialPath) => {
     return printedFragments;
 };
 
-const p = (node, path, print = print) => {
+const printAttribute = (node, path, print = print) => {
     node[EXPRESSION_NEEDED] = false;
     const docs = [path.call(print, "name")];
     node[EXPRESSION_NEEDED] = true;
@@ -47,4 +47,4 @@ const p = (node, path, print = print) => {
     return docs;
 };
 
-export { p as printAttribute };
+export { printAttribute };

--- a/src/print/AutoescapeBlock.js
+++ b/src/print/AutoescapeBlock.js
@@ -25,7 +25,7 @@ const createOpener = (node, options) => {
     ];
 };
 
-const p = (node, path, print, options) => {
+const printAutoescapeBlock = (node, path, print, options) => {
     const parts = [createOpener(node, options)];
     parts.push(printChildBlock(node, path, print, "expressions"));
     parts.push(
@@ -38,4 +38,4 @@ const p = (node, path, print, options) => {
     return parts;
 };
 
-export { p as printAutoescapeBlock };
+export { printAutoescapeBlock };

--- a/src/print/BinaryExpression.js
+++ b/src/print/BinaryExpression.js
@@ -65,7 +65,7 @@ const otherNeedsParentheses = (node, otherProp) => {
     );
 };
 
-const printBinaryExpression = (node, path, print) => {
+const internalPrintBinaryExpression = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
 
@@ -145,11 +145,11 @@ const printBinaryExpression = (node, path, print) => {
     return shouldGroupResult ? group(result) : result;
 };
 
-const p = (node, path, print, options) => {
+const printBinaryExpression = (node, path, print, options) => {
     if (Node.isBinaryConcatExpression(node) && node.wasImplicitConcatenation) {
         return printInterpolatedString(node, path, print, options);
     }
-    return printBinaryExpression(node, path, print);
+    return internalPrintBinaryExpression(node, path, print);
 };
 
-export { p as printBinaryExpression };
+export { printBinaryExpression };

--- a/src/print/BlockStatement.js
+++ b/src/print/BlockStatement.js
@@ -8,7 +8,7 @@ import {
 
 const { hardline, group } = doc.builders;
 
-const p = (node, path, print, options) => {
+const printBlockStatement = (node, path, print, options) => {
     node[EXPRESSION_NEEDED] = false;
     const hasChildren = Array.isArray(node.body);
     const printEndblockName = options.twigOutputEndblockName === true;
@@ -55,4 +55,4 @@ const p = (node, path, print, options) => {
     }
 };
 
-export { p as printBlockStatement };
+export { printBlockStatement };

--- a/src/print/CallExpression.js
+++ b/src/print/CallExpression.js
@@ -8,7 +8,7 @@ import {
 
 const { group, softline, line, indent, join } = doc.builders;
 
-const p = (node, path, print) => {
+const printCallExpression = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
     const mappedArguments = path.map(print, "arguments");
@@ -35,4 +35,4 @@ const p = (node, path, print) => {
     return group(parts);
 };
 
-export { p as printCallExpression };
+export { printCallExpression };

--- a/src/print/ConditionalExpression.js
+++ b/src/print/ConditionalExpression.js
@@ -7,7 +7,7 @@ import {
 
 const { line, indent, group } = doc.builders;
 
-const p = (node, path, print) => {
+const printConditionalExpression = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
 
@@ -24,4 +24,4 @@ const p = (node, path, print) => {
     return group(parts);
 };
 
-export { p as printConditionalExpression };
+export { printConditionalExpression };

--- a/src/print/Declaration.js
+++ b/src/print/Declaration.js
@@ -3,7 +3,7 @@ import { STRING_NEEDS_QUOTES, OVERRIDE_QUOTE_CHAR } from "../util/index.js";
 
 const { fill, join } = doc.builders;
 
-const p = (node, path, print) => {
+const printDeclaration = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     node[OVERRIDE_QUOTE_CHAR] = '"';
     const start = "<!" + (node.declarationType || "").toUpperCase();
@@ -12,4 +12,4 @@ const p = (node, path, print) => {
     return fill([start, " ", join(" ", printedParts), ">"]);
 };
 
-export { p as printDeclaration };
+export { printDeclaration };

--- a/src/print/DoStatement.js
+++ b/src/print/DoStatement.js
@@ -1,4 +1,4 @@
-const p = (node, path, print) => {
+const printDoStatement = (node, path, print) => {
     return [
         node.trimLeft ? "{%-" : "{%",
         " do ",
@@ -7,4 +7,4 @@ const p = (node, path, print) => {
     ];
 };
 
-export { p as printDoStatement };
+export { printDoStatement };

--- a/src/print/Element.js
+++ b/src/print/Element.js
@@ -46,7 +46,7 @@ const printSeparatedList = (path, print, separator, attrName) => {
     return join([separator, line], path.map(print, attrName));
 };
 
-const p = (node, path, print, options) => {
+const printElement = (node, path, print, options) => {
     // Set a flag in case attributes contain, e.g., a FilterExpression
     node[EXPRESSION_NEEDED] = true;
     const openingGroup = group(printOpeningTag(node, path, print, options));
@@ -83,4 +83,4 @@ const p = (node, path, print, options) => {
     return group(result, { id: groupElement });
 };
 
-export { p as printElement };
+export { printElement };

--- a/src/print/EmbedStatement.js
+++ b/src/print/EmbedStatement.js
@@ -22,7 +22,7 @@ const printOpener = (node, path, print) => {
     return group(parts);
 };
 
-const p = (node, path, print) => {
+const printEmbedStatement = (node, path, print) => {
     const children = printChildBlock(node, path, print, "blocks");
     const printedOpener = printOpener(node, path, print);
     const closing = [
@@ -35,4 +35,4 @@ const p = (node, path, print) => {
     return [printedOpener, children, closing];
 };
 
-export { p as printEmbedStatement };
+export { printEmbedStatement };

--- a/src/print/ExpressionStatement.js
+++ b/src/print/ExpressionStatement.js
@@ -8,7 +8,7 @@ import {
 
 const { group, indent, line } = doc.builders;
 
-const p = (node, path, print) => {
+const printExpressionStatement = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
     const opener = node.trimLeft ? "{{-" : "{{";
@@ -22,4 +22,4 @@ const p = (node, path, print) => {
     return group([opener, value, padding, closing]);
 };
 
-export { p as printExpressionStatement };
+export { printExpressionStatement };

--- a/src/print/ExtendsStatement.js
+++ b/src/print/ExtendsStatement.js
@@ -1,6 +1,6 @@
 import { STRING_NEEDS_QUOTES } from "../util/index.js";
 
-const p = (node, path, print) => {
+const printExtendsStatement = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     return [
         node.trimLeft ? "{%-" : "{%",
@@ -10,4 +10,4 @@ const p = (node, path, print) => {
     ];
 };
 
-export { p as printExtendsStatement };
+export { printExtendsStatement };

--- a/src/print/FilterBlockStatement.js
+++ b/src/print/FilterBlockStatement.js
@@ -10,7 +10,7 @@ const printOpeningGroup = (node, path, print) => {
     return group(parts);
 };
 
-const p = (node, path, print) => {
+const printFilterBlockStatement = (node, path, print) => {
     node[FILTER_BLOCK] = true;
     const openingGroup = printOpeningGroup(node, path, print);
     const body = printChildBlock(node, path, print, "body");
@@ -24,4 +24,4 @@ const p = (node, path, print) => {
     return [openingGroup, body, closingStatement];
 };
 
-export { p as printFilterBlockStatement };
+export { printFilterBlockStatement };

--- a/src/print/FilterExpression.js
+++ b/src/print/FilterExpression.js
@@ -53,7 +53,7 @@ const joinFilters = (filterExpressions, space = "") => {
     );
 };
 
-const p = (node, path, print, options) => {
+const printFilterExpression = (node, path, print, options) => {
     let currentNode = node;
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
@@ -128,4 +128,4 @@ const p = (node, path, print, options) => {
     return group(parts);
 };
 
-export { p as printFilterExpression };
+export { printFilterExpression };

--- a/src/print/FlushStatement.js
+++ b/src/print/FlushStatement.js
@@ -1,7 +1,7 @@
-const p = (node, path, print) => {
+const printFlushStatement = (node, path, print) => {
     const dashLeft = node.trimLeft ? "-" : "";
     const dashRight = node.trimRight ? "-" : "";
     return `{%${dashLeft} flush ${dashRight}%}`;
 };
 
-export { p as printFlushStatement };
+export { printFlushStatement };

--- a/src/print/ForStatement.js
+++ b/src/print/ForStatement.js
@@ -24,7 +24,7 @@ const printFor = (node, path, print) => {
     return group(parts);
 };
 
-const p = (node, path, print) => {
+const printForStatement = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     const parts = [printFor(node, path, print)];
     const isBodyEmpty =
@@ -55,4 +55,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printForStatement };
+export { printForStatement };

--- a/src/print/FromStatement.js
+++ b/src/print/FromStatement.js
@@ -11,7 +11,7 @@ const printImportDeclaration = node => {
     return parts;
 };
 
-const p = (node, path, print) => {
+const printFromStatement = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     // Unfortunately, ImportDeclaration has different
     // formatting needs here compared to when used
@@ -29,4 +29,4 @@ const p = (node, path, print) => {
     ]);
 };
 
-export { p as printFromStatement };
+export { printFromStatement };

--- a/src/print/GenericToken.js
+++ b/src/print/GenericToken.js
@@ -1,5 +1,5 @@
-const p = (node, path, print) => {
+const printGenericToken = (node, path, print) => {
     return node.tokenText;
 };
 
-export { p as printGenericToken };
+export { printGenericToken };

--- a/src/print/GenericTwigTag.js
+++ b/src/print/GenericTwigTag.js
@@ -9,7 +9,7 @@ import {
 
 const { hardline } = doc.builders;
 
-const p = (node, path, print) => {
+const printGenericTwigTag = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     const openingTag = printSingleTwigTag(node, path, print);
     const parts = [openingTag];
@@ -27,4 +27,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printGenericTwigTag };
+export { printGenericTwigTag };

--- a/src/print/HtmlComment.js
+++ b/src/print/HtmlComment.js
@@ -8,7 +8,7 @@ import {
 
 const { join, indent, hardline } = doc.builders;
 
-const p = (node, path, print) => {
+const printHtmlComment = (node, path, print) => {
     const commentText = stripHtmlCommentChars(node.value.value || "");
 
     const numNewlines = countNewlines(commentText);
@@ -19,4 +19,4 @@ const p = (node, path, print) => {
     return ["<!-- ", commentText, " -->"];
 };
 
-export { p as printHtmlComment };
+export { printHtmlComment };

--- a/src/print/Identifier.js
+++ b/src/print/Identifier.js
@@ -7,7 +7,7 @@ import {
 
 const { group } = doc.builders;
 
-const p = (node, path, print) => {
+const printIdentifier = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
 
@@ -21,4 +21,4 @@ const p = (node, path, print) => {
     return parts.length === 1 ? result : group(result);
 };
 
-export { p as printIdentifier };
+export { printIdentifier };

--- a/src/print/IfStatement.js
+++ b/src/print/IfStatement.js
@@ -12,7 +12,7 @@ const { group, indent, line, hardline } = doc.builders;
 
 const IS_ELSEIF = Symbol("IS_ELSEIF");
 
-const p = (node, path, print) => {
+const printIfStatement = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     const hasElseBranch =
         Array.isArray(node.alternate) && node.alternate.length > 0;
@@ -78,4 +78,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printIfStatement };
+export { printIfStatement };

--- a/src/print/ImportDeclaration.js
+++ b/src/print/ImportDeclaration.js
@@ -3,7 +3,7 @@ import { STRING_NEEDS_QUOTES } from "../util/index.js";
 
 const { group, line, indent } = doc.builders;
 
-const p = (node, path, print) => {
+const printImportDeclaration = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     return group([
         node.trimLeft ? "{%-" : "{%",
@@ -15,4 +15,4 @@ const p = (node, path, print) => {
     ]);
 };
 
-export { p as printImportDeclaration };
+export { printImportDeclaration };

--- a/src/print/IncludeStatement.js
+++ b/src/print/IncludeStatement.js
@@ -3,7 +3,7 @@ import { STRING_NEEDS_QUOTES } from "../util/index.js";
 
 const { group } = doc.builders;
 
-const p = (node, path, print) => {
+const printIncludeStatement = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     const parts = [
         node.trimLeft ? "{%-" : "{%",
@@ -23,4 +23,4 @@ const p = (node, path, print) => {
     return group(parts);
 };
 
-export { p as printIncludeStatement };
+export { printIncludeStatement };

--- a/src/print/MacroDeclarationStatement.js
+++ b/src/print/MacroDeclarationStatement.js
@@ -16,7 +16,7 @@ const printOpener = (node, path, print) => {
     return group(parts);
 };
 
-const p = (node, path, print) => {
+const printMacroDeclarationStatement = (node, path, print) => {
     const parts = [printOpener(node, path, print)];
     parts.push(indent([hardline, path.call(print, "body")]));
     parts.push(
@@ -28,4 +28,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printMacroDeclarationStatement };
+export { printMacroDeclarationStatement };

--- a/src/print/MemberExpression.js
+++ b/src/print/MemberExpression.js
@@ -7,7 +7,7 @@ import {
 
 const { group } = doc.builders;
 
-const p = (node, path, print) => {
+const printMemberExpression = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
     const parts = [path.call(print, "object")];
@@ -20,4 +20,4 @@ const p = (node, path, print) => {
     return group(parts);
 };
 
-export { p as printMemberExpression };
+export { printMemberExpression };

--- a/src/print/MountStatement.js
+++ b/src/print/MountStatement.js
@@ -59,7 +59,7 @@ const buildErrorHandling = (node, path, print) => {
     return parts;
 };
 
-const p = (node, path, print) => {
+const printMountStatement = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
     const parts = [buildOpener(node, path, print)];
@@ -81,4 +81,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printMountStatement };
+export { printMountStatement };

--- a/src/print/NamedArgumentExpression.js
+++ b/src/print/NamedArgumentExpression.js
@@ -1,6 +1,6 @@
 import { STRING_NEEDS_QUOTES } from "../util/index.js";
 
-const p = (node, path, print, options) => {
+const printNamedArgumentExpression = (node, path, print, options) => {
     node[STRING_NEEDS_QUOTES] = true;
     const printedName = path.call(print, "name");
     const printedValue = path.call(print, "value");
@@ -8,4 +8,4 @@ const p = (node, path, print, options) => {
     return [printedName, separator, printedValue];
 };
 
-export { p as printNamedArgumentExpression };
+export { printNamedArgumentExpression };

--- a/src/print/ObjectExpression.js
+++ b/src/print/ObjectExpression.js
@@ -3,7 +3,7 @@ import { EXPRESSION_NEEDED, wrapExpressionIfNeeded } from "../util/index.js";
 
 const { group, line, hardline, indent, join } = doc.builders;
 
-const p = (node, path, print, options) => {
+const printObjectExpression = (node, path, print, options) => {
     if (node.properties.length === 0) {
         return "{}";
     }
@@ -18,4 +18,4 @@ const p = (node, path, print, options) => {
     return group(parts);
 };
 
-export { p as printObjectExpression };
+export { printObjectExpression };

--- a/src/print/ObjectProperty.js
+++ b/src/print/ObjectProperty.js
@@ -1,7 +1,7 @@
 import { Node } from "../melody/melody-types/index.js";
 import { isValidIdentifierName, STRING_NEEDS_QUOTES } from "../util/index.js";
 
-const p = (node, path, print, options) => {
+const printObjectProperty = (node, path, print, options) => {
     node[STRING_NEEDS_QUOTES] =
         !node.computed &&
         Node.isStringLiteral(node.key) &&
@@ -28,4 +28,4 @@ const p = (node, path, print, options) => {
     return parts;
 };
 
-export { p as printObjectProperty };
+export { printObjectProperty };

--- a/src/print/SequenceExpression.js
+++ b/src/print/SequenceExpression.js
@@ -8,7 +8,7 @@ import {
 
 const { hardline } = doc.builders;
 
-const p = (node, path, print) => {
+const printSequenceExpression = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = false;
     node.expressions = removeSurroundingWhitespace(node.expressions);
     const items = printChildGroups(node, path, print, "expressions");
@@ -18,4 +18,4 @@ const p = (node, path, print) => {
     return items;
 };
 
-export { p as printSequenceExpression };
+export { printSequenceExpression };

--- a/src/print/SetStatement.js
+++ b/src/print/SetStatement.js
@@ -80,7 +80,7 @@ const printEmbracingSet = (node, path, print) => {
     return parts;
 };
 
-const p = (node, path, print) => {
+const printSetStatement = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     if (isEmbracingSet(node)) {
         return printEmbracingSet(node, path, print);
@@ -88,4 +88,4 @@ const p = (node, path, print) => {
     return printRegularSet(node, path, print);
 };
 
-export { p as printSetStatement };
+export { printSetStatement };

--- a/src/print/SliceExpression.js
+++ b/src/print/SliceExpression.js
@@ -1,8 +1,8 @@
-const p = (node, path, print) => {
+const printSliceExpression = (node, path, print) => {
     const printedTarget = path.call(print, "target");
     const printedStart = node.start ? path.call(print, "start") : "";
     const printedEnd = node.end ? path.call(print, "end") : "";
     return [printedTarget, "[", printedStart, ":", printedEnd, "]"];
 };
 
-export { p as printSliceExpression };
+export { printSliceExpression };

--- a/src/print/SpacelessBlock.js
+++ b/src/print/SpacelessBlock.js
@@ -3,7 +3,7 @@ import { printChildBlock } from "../util/index.js";
 
 const { hardline, group } = doc.builders;
 
-const p = (node, path, print) => {
+const printSpacelessBlock = (node, path, print) => {
     const parts = [
         node.trimLeft ? "{%-" : "{%",
         " spaceless ",
@@ -20,4 +20,4 @@ const p = (node, path, print) => {
     return result;
 };
 
-export { p as printSpacelessBlock };
+export { printSpacelessBlock };

--- a/src/print/StringLiteral.js
+++ b/src/print/StringLiteral.js
@@ -33,7 +33,7 @@ const getQuoteChar = (s, options) => {
     return quoteChar(options);
 };
 
-const p = (node, path, print, options) => {
+const printStringLiteral = (node, path, print, options) => {
     // The structure this string literal is part of
     // determines if we need quotes or not
     const needsQuotes = firstValueInAncestorChain(
@@ -60,4 +60,4 @@ const p = (node, path, print, options) => {
     return node.value;
 };
 
-export { p as printStringLiteral };
+export { printStringLiteral };

--- a/src/print/SwitchTag.js
+++ b/src/print/SwitchTag.js
@@ -9,7 +9,7 @@ import {
 
 const { indent, hardline } = doc.builders;
 
-const p = (node, path, print) => {
+const printSwitchTag = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     const openingTag = printSingleTwigTag(node, path, print);
     const parts = [openingTag];
@@ -32,4 +32,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printSwitchTag };
+export { printSwitchTag };

--- a/src/print/TestExpression.js
+++ b/src/print/TestExpression.js
@@ -18,7 +18,7 @@ const textMap = {
 const isNegator = node =>
     node.constructor.name === "UnarySubclass" && node.operator === "not";
 
-const p = (node, path, print) => {
+const printTestExpression = (node, path, print) => {
     node[STRING_NEEDS_QUOTES] = true;
     const expressionType = node.__proto__.type;
     const parts = [path.call(print, "expression"), " is "];
@@ -46,4 +46,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printTestExpression };
+export { printTestExpression };

--- a/src/print/TextStatement.js
+++ b/src/print/TextStatement.js
@@ -20,7 +20,7 @@ const newlinesOnly = (s, preserveWhitespace = true) => {
     return [hardline, hardline];
 };
 
-const p = (node, path, print) => {
+const printTextStatement = (node, path, print) => {
     // Check for special values that might have been
     // computed during preprocessing
     const preserveLeadingWhitespace =
@@ -42,4 +42,4 @@ const p = (node, path, print) => {
     return join([hardline, hardline], textGroups);
 };
 
-export { p as printTextStatement };
+export { printTextStatement };

--- a/src/print/TwigComment.js
+++ b/src/print/TwigComment.js
@@ -5,7 +5,7 @@ import {
     countNewlines
 } from "../util/index.js";
 
-const p = node => {
+const printTwigComment = node => {
     const originalText = node.value.value || "";
     const commentText = stripTwigCommentChars(originalText);
     const trimLeft = originalText.length >= 3 ? originalText[2] === "-" : false;
@@ -20,4 +20,4 @@ const p = node => {
     return [trimLeft ? "{#-" : "{#", commentText, trimRight ? "-#}" : "#}"];
 };
 
-export { p as printTwigComment };
+export { printTwigComment };

--- a/src/print/UnaryExpression.js
+++ b/src/print/UnaryExpression.js
@@ -7,7 +7,7 @@ import {
 
 const { group } = doc.builders;
 
-const p = (node, path, print) => {
+const printUnaryExpression = (node, path, print) => {
     node[EXPRESSION_NEEDED] = false;
     node[STRING_NEEDS_QUOTES] = true;
     const parts = [node.operator, path.call(print, "argument")];
@@ -15,4 +15,4 @@ const p = (node, path, print) => {
     return group(parts);
 };
 
-export { p as printUnaryExpression };
+export { printUnaryExpression };

--- a/src/print/UnarySubclass.js
+++ b/src/print/UnarySubclass.js
@@ -42,7 +42,7 @@ const printLogicalExpression = (node, path, print) => {
     return shouldCreateTopLevelGroup ? group(result) : result;
 };
 
-const p = (node, path, print) => {
+const printUnarySubclass = (node, path, print) => {
     // We need this part to prevent argument being wrapped into expression separated from operator
     // Example:
     // with node[EXPRESSION_NEEDED] = true; // default value
@@ -71,4 +71,4 @@ const p = (node, path, print) => {
     return parts;
 };
 
-export { p as printUnarySubclass };
+export { printUnarySubclass };

--- a/src/print/UseStatement.js
+++ b/src/print/UseStatement.js
@@ -2,7 +2,7 @@ import { doc } from "prettier";
 
 const { group, indent, join, line } = doc.builders;
 
-const p = (node, path, print) => {
+const printUseStatement = (node, path, print) => {
     const docs = [
         node.trimLeft ? "{%-" : "{%",
         ' use "',
@@ -22,4 +22,4 @@ const p = (node, path, print) => {
     return group(docs);
 };
 
-export { p as printUseStatement };
+export { printUseStatement };

--- a/src/print/VariableDeclarationStatement.js
+++ b/src/print/VariableDeclarationStatement.js
@@ -3,7 +3,7 @@ import { STRING_NEEDS_QUOTES, isContractableNodeType } from "../util/index.js";
 
 const { line, indent } = doc.builders;
 
-const p = (node, path, print) => {
+const printVariableDeclarationStatement = (node, path, print) => {
     const printedName = path.call(print, "name");
     node[STRING_NEEDS_QUOTES] = true;
     const printedValue = path.call(print, "value");
@@ -18,4 +18,4 @@ const p = (node, path, print) => {
     return [printedName, " =", rightHandSide];
 };
 
-export { p as printVariableDeclarationStatement };
+export { printVariableDeclarationStatement };


### PR DESCRIPTION
The modular print function has signature
```js
const p = (node, path, print, options) => {
    // function body here
}
```

It is easy to recognise which is the main function responsibe to build the doc. Unfortunately it has to be aliased when exported to prevent name collision. And it is not obvious where the callstack come from when debugging since it share the same name across multiple file/module.

__With Alias__
![Screen Shot 2024-12-18 at 15 46 56](https://github.com/user-attachments/assets/2f3bd361-3911-4d17-9268-311a9294909f)


__No Alias__
![Screen Shot 2024-12-18 at 15 46 12](https://github.com/user-attachments/assets/9638390e-4b6b-4c51-a61f-78dab191be48)
