### PR TITLE
Test: Stringify ast object on test setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+### Internal
+- Stringify ast object to make it easier to inspect when debugging on test setup
+
 ---
 ## 0.14.1 (2025-01-04)
 

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -3,6 +3,7 @@ import { resolve, extname, basename } from "path";
 import { URL, fileURLToPath } from "url";
 import { format, Options as PrettierOptions } from "prettier";
 import plugin from "src/index";
+import { parse } from "src/parser.js";
 
 /** @type {PrettierOptions} */
 const defaultOptions = {
@@ -79,12 +80,17 @@ export async function run_spec(metaUrl, options = {}) {
         "__snapshots__",
         generateSnapshotFileName(source, prefix, suffix)
     );
-    const actual = await format(code, {
+
+    /** @type {FormattingOptions} */
+    const actualOptions = {
         parser: "twig",
         plugins: [plugin],
         tabWidth: 4,
         ...formatOptions
-    });
+    };
+    const actual = await format(code, actualOptions);
+    const ast = await parse(code, null, actualOptions);
+    const astString = JSON.stringify(ast);
 
     return { snapshotFile, code, actual };
 }


### PR DESCRIPTION
Inspecting ast object using debugger is hard, especially when ast contains a lot of nested children.

__Example ast with nested children__
![Screen Shot 2025-01-15 at 12 12 08](https://github.com/user-attachments/assets/d029b228-a203-4e3c-915d-479e8ab96909)

There's a lot noise that might not relevant when inspecting ast structure.

__Example of strigified ast object__
![Screen Shot 2025-01-15 at 12 12 38](https://github.com/user-attachments/assets/5b01d9b6-539b-4efa-8e03-cf826ed0c20e)

IMO, stringified ast is easier to inspect.