### PR TITLE
Feature: Add support for twig comment as html element attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+### Features
+- [GH-61](https://github.com/zackad/prettier-plugin-twig/issues/61#issuecomment-2596726423) Add support for twig comment as html element attribute
+
 ### Internal
 - Stringify ast object to make it easier to inspect when debugging on test setup
 

--- a/src/melody/melody-parser/Parser.js
+++ b/src/melody/melody-parser/Parser.js
@@ -29,6 +29,7 @@ import { GenericTagParser } from "./GenericTagParser.js";
 import { createMultiTagParser } from "./GenericMultiTagParser.js";
 import { voidElements } from "./elementInfo.js";
 import * as he from "he";
+import { Attribute } from "../melody-types/index.js";
 
 /**
  * @typedef {Object} UnaryOperator
@@ -378,6 +379,7 @@ export default class Parser {
             tokens.lat(0) !== Types.ELEMENT_END
         ) {
             const key = tokens.nextIf(Types.SYMBOL);
+            let twigComment;
             if (key) {
                 const keyNode = new n.Identifier(key.text);
                 setStartFromToken(keyNode, key);
@@ -442,6 +444,10 @@ export default class Parser {
             } else if (tokens.nextIf(Types.EXPRESSION_START)) {
                 element.attributes.push(this.matchExpression());
                 tokens.expect(Types.EXPRESSION_END);
+            } else if ((twigComment = tokens.nextIf(Types.COMMENT))) {
+                const twigCommentValue = new n.StringLiteral(twigComment.text);
+                const twigCommentNode = new n.TwigComment(twigCommentValue);
+                element.attributes.push(twigCommentNode);
             } else {
                 this.error({
                     title: "Invalid token",

--- a/tests/Element/__snapshots__/attribute_twig_comment.snap.twig
+++ b/tests/Element/__snapshots__/attribute_twig_comment.snap.twig
@@ -1,0 +1,1 @@
+<button {# Some comment here #}>Foo</button>

--- a/tests/Element/attribute_twig_comment.twig
+++ b/tests/Element/attribute_twig_comment.twig
@@ -1,0 +1,5 @@
+<button
+  {# Some comment here #}
+>
+  Foo
+</button>

--- a/tests/Element/jsfmt.spec.js
+++ b/tests/Element/jsfmt.spec.js
@@ -8,6 +8,14 @@ describe("Elements", () => {
         });
         expect(actual).toMatchFileSnapshot(snapshotFile);
     });
+
+    it("should handle attribute with twig comment", async () => {
+        const { actual, snapshotFile } = await run_spec(import.meta.url, {
+            source: "attribute_twig_comment.twig"
+        });
+        expect(actual).toMatchFileSnapshot(snapshotFile);
+    });
+
     it("should handle attributes", async () => {
         const { actual, snapshotFile } = await run_spec(import.meta.url, {
             source: "attributes.twig"


### PR DESCRIPTION
Partially implement GH-61

This will allow twig comment inside html element as attribute.

__Example__
```twig
<button
    type="button"
    {# Some comment here #}
    class="flex-shrink-0 size-6 grid place-items-center"
>
    Foo
</button>
```

> [!NOTE]
> Do not put comment as attribute value

__Invalid__
```twig
<button
    type="button"
    comment="{# Some comment here #}"
    class="flex-shrink-0 size-6 grid place-items-center"
>
    Foo
</button>
```