### PR TITLE
[WIP] Feature: Allow twig tag as html attribute

### DIFF
--- a/src/melody/melody-extension-core/parser/block.js
+++ b/src/melody/melody-extension-core/parser/block.js
@@ -37,18 +37,20 @@ export const BlockParser = {
         let openingTagEndToken;
         let closingTagStartToken;
         if ((openingTagEndToken = tokens.nextIf(Types.TAG_END))) {
+            const blockName = createNode(Identifier, nameToken, nameToken.text);
+            const blockBody = parser.parse((tokenText, token, tokens) => {
+                const result = !!(
+                    token.type === Types.TAG_START &&
+                    tokens.nextIf(Types.SYMBOL, "endblock")
+                );
+                if (result) {
+                    closingTagStartToken = token;
+                }
+                return result;
+            });
             blockStatement = new BlockStatement(
-                createNode(Identifier, nameToken, nameToken.text),
-                parser.parse((tokenText, token, tokens) => {
-                    const result = !!(
-                        token.type === Types.TAG_START &&
-                        tokens.nextIf(Types.SYMBOL, "endblock")
-                    );
-                    if (result) {
-                        closingTagStartToken = token;
-                    }
-                    return result;
-                }).expressions
+                blockName,
+                blockBody.expressions
             );
 
             if (tokens.nextIf(Types.SYMBOL, nameToken.text)) {

--- a/src/melody/melody-parser/Parser.js
+++ b/src/melody/melody-parser/Parser.js
@@ -444,6 +444,9 @@ export default class Parser {
             } else if (tokens.nextIf(Types.EXPRESSION_START)) {
                 element.attributes.push(this.matchExpression());
                 tokens.expect(Types.EXPRESSION_END);
+            } else if (tokens.nextIf(Types.TAG_START)) {
+                const tagExpression = this.matchTag();
+                element.attributes.push(tagExpression);
             } else if ((twigComment = tokens.nextIf(Types.COMMENT))) {
                 const twigCommentValue = new n.StringLiteral(twigComment.text);
                 const twigCommentNode = new n.TwigComment(twigCommentValue);

--- a/tests/Element/__snapshots__/attribute_twig_tag.snap.twig
+++ b/tests/Element/__snapshots__/attribute_twig_tag.snap.twig
@@ -1,0 +1,9 @@
+<div
+    {% block class %}
+        contenteditable="true"
+    {% endblock %}
+></div>
+
+{% block class %}
+    class="hidden"
+{% endblock %}

--- a/tests/Element/attribute_twig_tag.twig
+++ b/tests/Element/attribute_twig_tag.twig
@@ -1,0 +1,4 @@
+<div {% block class %}contenteditable="true"{% endblock class %}>
+</div>
+
+{% block class %}class="hidden"{% endblock class %}

--- a/tests/Element/jsfmt.spec.js
+++ b/tests/Element/jsfmt.spec.js
@@ -16,6 +16,13 @@ describe("Elements", () => {
         expect(actual).toMatchFileSnapshot(snapshotFile);
     });
 
+    it("should handle attribute with twig tag", async () => {
+        const { actual, snapshotFile } = await run_spec(import.meta.url, {
+            source: "attribute_twig_tag.twig"
+        });
+        expect(actual).toMatchFileSnapshot(snapshotFile);
+    });
+
     it("should handle attributes", async () => {
         const { actual, snapshotFile } = await run_spec(import.meta.url, {
             source: "attributes.twig"


### PR DESCRIPTION
Related GH-61

__TODO__:
- [ ] need to investigate why block statement body is missing when parsed from html attribute