### PR TITLE
Feature: Allow registering custom Twig tests expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - [GH-61](https://github.com/zackad/prettier-plugin-twig/issues/61#issuecomment-2596726423) Add support for twig comment as html element attribute
+- [GH-116](https://github.com/zackad/prettier-plugin-twig/issues/116) Add possibility to register any custom Twig test expression
 
 ### Bugfixes
 - Fix broken embed statement with `only` modifier

--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ If we did not list the `"nav,endnav"` entry in `twigMultiTags`, this code exampl
 
 Note that the order matters: It has to be `"nav,endnav"`, and it must not be `"endnav,nav"`. In general, the first and the last tag name matter. In the case of `"switch,case,default,endswitch"`, the order of `case` and `default` does not matter. However, `switch` has to come first, and `endswitch` has to come last.
 
+### twigTestExpressions (default: `[]`)
+
+Make custom Twig tests known to the parser.
+
+```json
+twigTestExpressions: [
+    "snake_case_test",
+    "camelCaseTest"
+]
+```
+
+__Example__
+```twig
+{{ a is snake_case_test }}
+{{ a is not snake_case_test }}
+{{ a is camelCaseTest }}
+{{ a is not camelCaseTest }}
+```
+
 ## Features
 
 ### `prettier-ignore` and `prettier-ignore-start`

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,13 @@ const printers = {
 
 /** @type {import('prettier').Options} Options */
 const options = {
+    twigTestExpressions: {
+        type: "path",
+        category: "Global",
+        array: true,
+        default: [{ value: [] }],
+        description: "Make custom Twig tests known to the parser."
+    },
     twigMultiTags: {
         type: "path",
         category: "Global",

--- a/src/melody/melody-extension-core/operators.js
+++ b/src/melody/melody-extension-core/operators.js
@@ -353,7 +353,7 @@ export const TestInstanceOfExpression = createTest(
 //endregion
 
 //region Utilities
-function createTest(text, typeName) {
+export function createTest(text, typeName) {
     const TestExpression = class extends Node {
         /**
          * @param {Node} expr

--- a/src/melody/melody-extension-core/operators.js
+++ b/src/melody/melody-extension-core/operators.js
@@ -301,13 +301,19 @@ export const BinaryEmptyCoalesceExpression = createBinaryOperatorNode({
 //endregion
 
 //region Test Expressions
-export const TestEvenExpression = createTest("even", "TestEvenExpression");
-export const TestOddExpression = createTest("odd", "TestOddExpression");
-export const TestDefinedExpression = createTest(
+export const TestEvenExpression = createTestExpression(
+    "even",
+    "TestEvenExpression"
+);
+export const TestOddExpression = createTestExpression(
+    "odd",
+    "TestOddExpression"
+);
+export const TestDefinedExpression = createTestExpression(
     "defined",
     "TestDefinedExpression"
 );
-export const TestSameAsExpression = createTest(
+export const TestSameAsExpression = createTestExpression(
     "same as",
     "TestSameAsExpression"
 );
@@ -318,14 +324,17 @@ tests.push({
         return new TestSameAsExpression(expr, args);
     }
 });
-export const TestNullExpression = createTest("null", "TestNullExpression");
+export const TestNullExpression = createTestExpression(
+    "null",
+    "TestNullExpression"
+);
 tests.push({
     text: "none",
     createNode(expr, args) {
         return new TestNullExpression(expr, args);
     }
 });
-export const TestDivisibleByExpression = createTest(
+export const TestDivisibleByExpression = createTestExpression(
     "divisible by",
     "TestDivisibleByExpression"
 );
@@ -336,24 +345,26 @@ tests.push({
         return new TestDivisibleByExpression(expr, args);
     }
 });
-export const TestConstantExpression = createTest(
+export const TestConstantExpression = createTestExpression(
     "constant",
     "TestConstantExpression"
 );
-export const TestEmptyExpression = createTest("empty", "TestEmptyExpression");
-export const TestIterableExpression = createTest(
+export const TestEmptyExpression = createTestExpression(
+    "empty",
+    "TestEmptyExpression"
+);
+export const TestIterableExpression = createTestExpression(
     "iterable",
     "TestIterableExpression"
 );
-
-export const TestInstanceOfExpression = createTest(
+export const TestInstanceOfExpression = createTestExpression(
     "instance of",
     "TestInstanceOfExpression"
 );
 //endregion
 
 //region Utilities
-export function createTest(text, typeName) {
+export function createTestExpression(text, typeName) {
     const TestExpression = class extends Node {
         /**
          * @param {Node} expr

--- a/src/parser.js
+++ b/src/parser.js
@@ -5,7 +5,7 @@ import {
     Parser
 } from "./melody/melody-parser/index.js";
 import { extension as coreExtension } from "./melody/melody-extension-core/index.js";
-import { createTest } from "./melody/melody-extension-core/operators.js";
+import { createTestExpression } from "./melody/melody-extension-core/operators.js";
 
 const ORIGINAL_SOURCE = Symbol("ORIGINAL_SOURCE");
 
@@ -77,7 +77,7 @@ const getMultiTagConfig = (tagsCsvs = []) =>
 
 const registerTestExtensions = (testExpressions = []) => {
     testExpressions.forEach(test =>
-        createTest(test, `Test[${test}]Expression`)
+        createTestExpression(test, `Test[${test}]Expression`)
     );
 };
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -5,6 +5,7 @@ import {
     Parser
 } from "./melody/melody-parser/index.js";
 import { extension as coreExtension } from "./melody/melody-extension-core/index.js";
+import { createTest } from "./melody/melody-extension-core/operators.js";
 
 const ORIGINAL_SOURCE = Symbol("ORIGINAL_SOURCE");
 
@@ -74,8 +75,15 @@ const getMultiTagConfig = (tagsCsvs = []) =>
         return acc;
     }, {});
 
+const registerTestExtensions = (testExpressions = []) => {
+    testExpressions.forEach(test =>
+        createTest(test, `Test[${test}]Expression`)
+    );
+};
+
 const parse = (text, parsers, options) => {
     const multiTagConfig = getMultiTagConfig(options.twigMultiTags || []);
+    registerTestExtensions(options.twigTestExpressions || []);
 
     const extensions = [coreExtension];
     const parser = createConfiguredParser(text, multiTagConfig, ...extensions);

--- a/src/print/TestExpression.js
+++ b/src/print/TestExpression.js
@@ -28,7 +28,15 @@ const printTestExpression = (node, path, print) => {
     if (isNegator(parent)) {
         parts.push("not ");
     }
-    if (!textMap[expressionType]) {
+
+    if (expressionType.includes("[") && expressionType.includes("]")) {
+        const testText = expressionType.substring(
+            expressionType.indexOf("[") + 1,
+            expressionType.lastIndexOf("]")
+        );
+
+        parts.push(testText);
+    } else if (!textMap[expressionType]) {
         console.error(
             "TestExpression: No text for " + expressionType + " defined"
         );

--- a/tests/Expressions/__snapshots__/custom_test_expression.snap.twig
+++ b/tests/Expressions/__snapshots__/custom_test_expression.snap.twig
@@ -1,0 +1,4 @@
+{{ a is snake_case_test }}
+{{ a is not snake_case_test }}
+{{ a is camelCaseTest }}
+{{ a is not camelCaseTest }}

--- a/tests/Expressions/custom_test_expression.twig
+++ b/tests/Expressions/custom_test_expression.twig
@@ -1,0 +1,4 @@
+{{ a is snake_case_test }}
+{{ a is not snake_case_test }}
+{{ a is camelCaseTest }}
+{{ a is not camelCaseTest }}

--- a/tests/Expressions/jsfmt.spec.js
+++ b/tests/Expressions/jsfmt.spec.js
@@ -91,4 +91,13 @@ describe("Expressions", () => {
         });
         await expect(actual).toMatchFileSnapshot(snapshotFile);
     });
+    it("should handle custom test expressions", async () => {
+        const { actual, snapshotFile } = await run_spec(import.meta.url, {
+            source: "custom_test_expression.twig",
+            formatOptions: {
+                twigTestExpressions: ["snake_case_test", "camelCaseTest"]
+            }
+        });
+        await expect(actual).toMatchFileSnapshot(snapshotFile);
+    });
 });


### PR DESCRIPTION
This PR adds the new config option `twigTestExpressions`, which allows the user to register any custom Twig tests. This makes those custom tests known to the parser without throwing any errors.

@zackad I tried to add the functionality with the best of my knowledge on how to integrate something like that in a Prettier plugin, like this one. I hope we can work with that and I'm always very grateful for inputs. Let me know, if I can do something differently to refactor this implementation.