### PR TITLE
Improve `UNEXPECTED_TOKEN` errors

### DIFF
--- a/src/melody/melody-parser/GenericTagParser.js
+++ b/src/melody/melody-parser/GenericTagParser.js
@@ -34,7 +34,7 @@ export const GenericTagParser = {
                 } catch (e) {
                     if (e.errorType === "UNEXPECTED_TOKEN") {
                         twigTag.parts.push(
-                            new n.GenericToken(e.tokenType, e.tokenText)
+                            new n.GenericToken(e.token.type, e.token.text)
                         );
                         tokens.next();
                     } else {

--- a/src/melody/melody-parser/Parser.js
+++ b/src/melody/melody-parser/Parser.js
@@ -29,7 +29,6 @@ import { GenericTagParser } from "./GenericTagParser.js";
 import { createMultiTagParser } from "./GenericMultiTagParser.js";
 import { voidElements } from "./elementInfo.js";
 import * as he from "he";
-import { Attribute } from "../melody-types/index.js";
 
 /**
  * @typedef {Object} UnaryOperator

--- a/src/melody/melody-parser/Parser.js
+++ b/src/melody/melody-parser/Parser.js
@@ -648,8 +648,7 @@ export default class Parser {
                         },
                         {
                             errorType: "UNEXPECTED_TOKEN",
-                            tokenText: token.text,
-                            tokenType: token.type
+                            token
                         }
                     );
                 }

--- a/src/melody/melody-parser/TokenStream.js
+++ b/src/melody/melody-parser/TokenStream.js
@@ -106,7 +106,11 @@ export default class TokenStream {
             `Expected ${ERROR_TABLE[type] || type || text} but found ${
                 ERROR_TABLE[token.type] || token.type || token.text
             } instead.`,
-            token.length
+            token.length,
+            {
+                errorType: "UNEXPECTED_TOKEN",
+                token
+            }
         );
     }
 


### PR DESCRIPTION
This pull request is split from #149.

---

Two changes that serve as groundwork to improve error handling:

1. Assign the token _instance_ to the error object instead of just the token _type_ and _text_. This allows handlers to act upon the token's context such as the start and end positions of the errored token and source statement containing the error.
2. Add the error type `UNEXPECTED_TOKEN` to the "Invalid Token" error [thrown by `TokenStream.expect()`](https://github.com/zackad/prettier-plugin-twig/blob/v0.17.0/src/melody/melody-parser/TokenStream.js#L103-L110) to match the similar error type [thrown by `Parser.matchPrimaryExpression()`](https://github.com/zackad/prettier-plugin-twig/blob/v0.17.0/src/melody/melody-parser/Parser.js#L640-L655). This error type is [caught by `GenericTagParser`](https://github.com/zackad/prettier-plugin-twig/blob/v0.17.0/src/melody/melody-parser/GenericTagParser.js#L34-L43) to assemble a plain tag statement.